### PR TITLE
Add Tkinter-based money allocation manager UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.pyo
+*.db
+*.sqlite3
+*.log
+.DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+# Money Allocation Manager
+
+A desktop application written in Python that helps you design and maintain a multi-level money allocation plan.  
+It stores your allocations in a local SQLite database (`allocations.db`) and provides a convenient tree-based editor for creating, updating and removing buckets.
+
+## Features
+
+- Visualise your allocation hierarchy in a multi-column tree view.
+- Create, edit and delete buckets with arbitrary nesting depth.
+- Track both the share relative to the parent bucket and the cumulative share of the overall plan.
+- Mark buckets as *included* or *excluded* from the aggregated roll-up percentages.
+- Attach notes to every allocation for additional context.
+- Import a comprehensive sample dataset or replace your data from a CSV export.
+- Export the current database contents to CSV for backups or further processing.
+
+## Getting started
+
+The application only requires the Python standard library (Tkinter is bundled with CPython on all major platforms).
+
+1. Ensure you are using Python 3.11 or later.
+2. Install the project in editable mode or simply run the entry module directly:
+
+```bash
+python -m moneyalloc_app
+```
+
+Alternatively you can use the helper script:
+
+```bash
+python main.py
+```
+
+On first launch an empty database is created next to the Python modules. Use **File → Import sample data** to load a detailed example hierarchy inspired by the plan provided in the task description.
+
+## Working with the UI
+
+- **Add root** creates a new top-level allocation that counts directly towards the global total.
+- **Add child** creates a nested allocation under the currently selected bucket.
+- **Edit** opens the selected bucket for changes. Saving updates the database immediately.
+- **Delete** removes the selected bucket and all of its descendants.
+- **Expand all / Collapse all** control the visibility of the hierarchy tree.
+- The form on the right displays the details of the selection and exposes fields when you are adding or editing items.
+
+The *Children share* label helps you verify that the percentages of the immediate children sum up correctly for the selected parent.
+
+## CSV import/export format
+
+Exports contain the following columns:
+
+| Column | Description |
+| ------ | ----------- |
+| `id` | Unique identifier of the allocation. |
+| `parent_id` | Identifier of the parent allocation (empty for top-level rows). |
+| `name` | Display name of the bucket. |
+| `currency` | Optional currency label. |
+| `target_percent` | Share of the parent bucket expressed as a percentage. |
+| `include_in_rollup` | `1` if the allocation contributes to the overall totals, otherwise `0`. |
+| `notes` | Free-form description or comments. |
+| `sort_order` | Integer describing the order of siblings. |
+
+When importing from CSV you must keep these columns (you can edit the values).  
+The application clears the current database before inserting the imported rows.
+
+## Database location
+
+The database file `allocations.db` lives inside the `moneyalloc_app` package directory by default. You can back it up or version it as needed. Deleting the file will reset the app.
+
+## Development notes
+
+- The project intentionally avoids third-party dependencies to ease distribution.
+- The default Tkinter theme is switched to `clam` when available to provide a modern appearance.
+- Sample data is declared programmatically in `moneyalloc_app/sample_data.py` and can be used as a template for further customisation.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,6 @@
+"""Entry point for launching the Money Allocation Manager UI."""
+from moneyalloc_app import run_app
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch only
+    run_app()

--- a/moneyalloc_app/__init__.py
+++ b/moneyalloc_app/__init__.py
@@ -1,0 +1,6 @@
+"""Money allocation manager package."""
+from .app import AllocationApp, run_app
+from .db import AllocationRepository
+from .models import Allocation
+
+__all__ = ["AllocationApp", "AllocationRepository", "Allocation", "run_app"]

--- a/moneyalloc_app/app.py
+++ b/moneyalloc_app/app.py
@@ -1,0 +1,569 @@
+"""Tkinter user interface for managing hierarchical money allocations."""
+from __future__ import annotations
+
+import csv
+import tkinter as tk
+from dataclasses import dataclass
+from pathlib import Path
+from tkinter import filedialog, messagebox, ttk
+from typing import Dict, Iterable, Optional
+
+from .db import AllocationRepository
+from .models import Allocation
+from .sample_data import populate_with_sample_data
+
+
+@dataclass
+class TreeNode:
+    allocation: Allocation
+    children: list["TreeNode"]
+
+
+class AllocationApp(ttk.Frame):
+    """Main application frame that hosts the tree and the editor form."""
+
+    def __init__(self, master: tk.Tk, repo: Optional[AllocationRepository] = None) -> None:
+        super().__init__(master, padding=10)
+        self.master.title("Money Allocation Manager")
+        self.repo = repo or AllocationRepository()
+        self.mode: str = "view"  # view | add | edit
+        self.parent_for_new: Optional[int] = None
+        self.selected_id: Optional[int] = None
+        self.allocation_cache: Dict[int, Allocation] = {}
+
+        self.name_var = tk.StringVar()
+        self.currency_var = tk.StringVar()
+        self.percent_var = tk.StringVar()
+        self.include_var = tk.BooleanVar(value=True)
+        self.path_var = tk.StringVar(value="No selection")
+        self.child_sum_var = tk.StringVar(value="Children share: 0.00% of parent")
+        self.status_var = tk.StringVar(value="Welcome! Use the buttons above to manage allocations.")
+
+        self.grid(column=0, row=0, sticky="nsew")
+        self.master.rowconfigure(0, weight=1)
+        self.master.columnconfigure(0, weight=1)
+
+        self._create_menu()
+        self._create_widgets()
+        self.refresh_tree()
+
+    # ------------------------------------------------------------------
+    # UI construction helpers
+    # ------------------------------------------------------------------
+    def _create_menu(self) -> None:
+        menubar = tk.Menu(self.master)
+
+        file_menu = tk.Menu(menubar, tearoff=False)
+        file_menu.add_command(label="Import sample data", command=self._import_sample_data)
+        file_menu.add_separator()
+        file_menu.add_command(label="Import from CSV…", command=self._import_from_csv)
+        file_menu.add_command(label="Export to CSV…", command=self._export_to_csv)
+        file_menu.add_separator()
+        file_menu.add_command(label="Exit", command=self.master.destroy)
+        menubar.add_cascade(label="File", menu=file_menu)
+
+        self.master.config(menu=menubar)
+
+    def _create_widgets(self) -> None:
+        # Toolbar with common actions
+        toolbar = ttk.Frame(self)
+        toolbar.grid(row=0, column=0, columnspan=2, sticky="ew", pady=(0, 10))
+        toolbar.columnconfigure(tuple(range(10)), weight=1)
+
+        ttk.Button(toolbar, text="Add root", command=self._start_add_root).grid(row=0, column=0, padx=2)
+        ttk.Button(toolbar, text="Add child", command=self._start_add_child).grid(row=0, column=1, padx=2)
+        ttk.Button(toolbar, text="Edit", command=self._start_edit).grid(row=0, column=2, padx=2)
+        self.save_button = ttk.Button(toolbar, text="Save", command=self._save_allocation, state="disabled")
+        self.save_button.grid(row=0, column=3, padx=2)
+        self.cancel_button = ttk.Button(toolbar, text="Cancel", command=self._cancel_edit, state="disabled")
+        self.cancel_button.grid(row=0, column=4, padx=2)
+        ttk.Button(toolbar, text="Delete", command=self._delete_allocation).grid(row=0, column=5, padx=2)
+        ttk.Button(toolbar, text="Expand all", command=lambda: self._expand_collapse(True)).grid(row=0, column=6, padx=2)
+        ttk.Button(toolbar, text="Collapse all", command=lambda: self._expand_collapse(False)).grid(row=0, column=7, padx=2)
+
+        # Tree view with scrollbars
+        tree_frame = ttk.Frame(self)
+        tree_frame.grid(row=1, column=0, sticky="nsew")
+        tree_frame.rowconfigure(0, weight=1)
+        tree_frame.columnconfigure(0, weight=1)
+
+        columns = ("currency", "target", "cumulative", "included")
+        self.tree = ttk.Treeview(tree_frame, columns=columns, show="tree headings", selectmode="browse")
+        self.tree.heading("#0", text="Allocation")
+        self.tree.heading("currency", text="Currency")
+        self.tree.heading("target", text="Share of parent")
+        self.tree.heading("cumulative", text="Share of total")
+        self.tree.heading("included", text="Included")
+        self.tree.column("#0", width=240)
+        self.tree.column("currency", width=80, anchor="center")
+        self.tree.column("target", width=120, anchor="e")
+        self.tree.column("cumulative", width=120, anchor="e")
+        self.tree.column("included", width=80, anchor="center")
+        self.tree.bind("<<TreeviewSelect>>", self._on_tree_select)
+        self.tree.grid(row=0, column=0, sticky="nsew")
+
+        tree_scroll_y = ttk.Scrollbar(tree_frame, orient="vertical", command=self.tree.yview)
+        tree_scroll_x = ttk.Scrollbar(tree_frame, orient="horizontal", command=self.tree.xview)
+        self.tree.configure(yscrollcommand=tree_scroll_y.set, xscrollcommand=tree_scroll_x.set)
+        tree_scroll_y.grid(row=0, column=1, sticky="ns")
+        tree_scroll_x.grid(row=1, column=0, sticky="ew")
+
+        # Editor form
+        form = ttk.LabelFrame(self, text="Allocation details")
+        form.grid(row=1, column=1, padx=(10, 0), sticky="nsew")
+        form.columnconfigure(1, weight=1)
+        form.rowconfigure(6, weight=1)
+
+        ttk.Label(form, text="Path:").grid(row=0, column=0, sticky="w")
+        ttk.Label(form, textvariable=self.path_var, wraplength=260).grid(row=0, column=1, sticky="w")
+
+        ttk.Label(form, text="Name:").grid(row=1, column=0, sticky="w", pady=(6, 0))
+        self.name_entry = ttk.Entry(form, textvariable=self.name_var, width=30)
+        self.name_entry.grid(row=1, column=1, sticky="ew", pady=(6, 0))
+
+        ttk.Label(form, text="Currency:").grid(row=2, column=0, sticky="w", pady=(6, 0))
+        self.currency_entry = ttk.Entry(form, textvariable=self.currency_var)
+        self.currency_entry.grid(row=2, column=1, sticky="ew", pady=(6, 0))
+
+        ttk.Label(form, text="Share of parent (%):").grid(row=3, column=0, sticky="w", pady=(6, 0))
+        self.percent_entry = ttk.Entry(form, textvariable=self.percent_var)
+        self.percent_entry.grid(row=3, column=1, sticky="ew", pady=(6, 0))
+
+        ttk.Label(form, text="Included in roll-up:").grid(row=4, column=0, sticky="w", pady=(6, 0))
+        self.include_check = ttk.Checkbutton(form, variable=self.include_var, text="Yes")
+        self.include_check.grid(row=4, column=1, sticky="w", pady=(6, 0))
+
+        ttk.Label(form, text="Notes:").grid(row=5, column=0, sticky="nw", pady=(6, 0))
+        self.notes_text = tk.Text(form, height=8, wrap="word")
+        self.notes_text.grid(row=5, column=1, sticky="nsew", pady=(6, 0))
+        notes_scroll = ttk.Scrollbar(form, orient="vertical", command=self.notes_text.yview)
+        self.notes_text.configure(yscrollcommand=notes_scroll.set)
+        notes_scroll.grid(row=5, column=2, sticky="nsw")
+
+        ttk.Label(form, textvariable=self.child_sum_var).grid(row=6, column=0, columnspan=2, sticky="w", pady=(6, 0))
+
+        # Status bar
+        status = ttk.Label(self, textvariable=self.status_var, anchor="w")
+        status.grid(row=2, column=0, columnspan=2, sticky="ew", pady=(10, 0))
+
+        self.rowconfigure(1, weight=1)
+        self.columnconfigure(0, weight=3)
+        self.columnconfigure(1, weight=2)
+
+        self._set_form_state(False)
+
+    # ------------------------------------------------------------------
+    # Menu actions
+    # ------------------------------------------------------------------
+    def _import_sample_data(self) -> None:
+        if not messagebox.askyesno(
+            "Replace data",
+            "This will load a curated sample dataset. Existing allocations will be removed. Continue?",
+        ):
+            return
+        populate_with_sample_data(self.repo, replace=True)
+        self.refresh_tree()
+        self.status_var.set("Sample data imported successfully.")
+
+    def _import_from_csv(self) -> None:
+        path = filedialog.askopenfilename(
+            title="Import allocations from CSV",
+            filetypes=[("CSV files", "*.csv"), ("All files", "*.*")],
+        )
+        if not path:
+            return
+        if not messagebox.askyesno(
+            "Replace data",
+            "Importing from CSV will replace all existing allocations. Continue?",
+        ):
+            return
+        try:
+            allocations: list[Allocation] = []
+            with open(path, "r", encoding="utf-8") as fh:
+                reader = csv.DictReader(fh)
+                required = {"id", "parent_id", "name", "currency", "target_percent", "include_in_rollup", "notes", "sort_order"}
+                if not required.issubset(reader.fieldnames or []):
+                    missing = required.difference(reader.fieldnames or [])
+                    raise ValueError(f"Missing columns in CSV: {', '.join(sorted(missing))}")
+                for row in reader:
+                    if not row["name"].strip():
+                        continue
+                    allocations.append(
+                        Allocation(
+                            id=int(row["id"]) if row["id"].strip() else None,
+                            parent_id=int(row["parent_id"]) if row["parent_id"].strip() else None,
+                            name=row["name"].strip(),
+                            currency=row["currency"].strip() or None,
+                            target_percent=float(row["target_percent"] or 0.0),
+                            include_in_rollup=row["include_in_rollup"].strip().lower() in {"1", "true", "yes"},
+                            notes=row["notes"],
+                            sort_order=int(row["sort_order"] or 0),
+                        )
+                    )
+            self.repo.clear_all()
+            # When ids are provided we insert them directly to preserve hierarchy order.
+            self.repo.bulk_insert(allocations)
+        except Exception as exc:  # noqa: BLE001 - show the error to the user
+            messagebox.showerror("Import failed", f"Could not import data: {exc}")
+            return
+        self.refresh_tree()
+        self.status_var.set(f"Imported {len(allocations)} allocations from CSV.")
+
+    def _export_to_csv(self) -> None:
+        path = filedialog.asksaveasfilename(
+            title="Export allocations to CSV",
+            defaultextension=".csv",
+            filetypes=[("CSV files", "*.csv"), ("All files", "*.*")],
+        )
+        if not path:
+            return
+        allocations = self.repo.get_all_allocations()
+        try:
+            with open(path, "w", encoding="utf-8", newline="") as fh:
+                writer = csv.writer(fh)
+                writer.writerow(
+                    [
+                        "id",
+                        "parent_id",
+                        "name",
+                        "currency",
+                        "target_percent",
+                        "include_in_rollup",
+                        "notes",
+                        "sort_order",
+                    ]
+                )
+                for allocation in allocations:
+                    writer.writerow(
+                        [
+                            allocation.id,
+                            allocation.parent_id if allocation.parent_id is not None else "",
+                            allocation.name,
+                            allocation.currency or "",
+                            f"{allocation.target_percent:.4f}",
+                            int(allocation.include_in_rollup),
+                            allocation.notes,
+                            allocation.sort_order,
+                        ]
+                    )
+        except OSError as exc:  # pragma: no cover - we simply report errors
+            messagebox.showerror("Export failed", f"Could not write file: {exc}")
+            return
+        self.status_var.set(f"Exported {len(allocations)} allocations to {Path(path).name}.")
+
+    # ------------------------------------------------------------------
+    # Toolbar actions
+    # ------------------------------------------------------------------
+    def _start_add_root(self) -> None:
+        self.parent_for_new = None
+        self._begin_edit_mode("add", "Adding a new top-level allocation")
+
+    def _start_add_child(self) -> None:
+        if not self.selected_id:
+            messagebox.showinfo("Select a node", "Select a parent allocation in the tree first.")
+            return
+        self.parent_for_new = self.selected_id
+        parent_path = self._get_path(self.parent_for_new)
+        self._begin_edit_mode("add", f"Adding a new child under {parent_path}")
+
+    def _start_edit(self) -> None:
+        if not self.selected_id:
+            messagebox.showinfo("Select a node", "Choose an allocation to edit from the tree.")
+            return
+        self.parent_for_new = None
+        self._begin_edit_mode("edit", "Editing existing allocation")
+
+    def _begin_edit_mode(self, mode: str, status_message: str) -> None:
+        self.mode = mode
+        if mode == "add":
+            self.selected_id = None
+            self._clear_form()
+            parent_path = (
+                "Top level" if self.parent_for_new is None else self._get_path(self.parent_for_new)
+            )
+            self.path_var.set(parent_path)
+        elif mode == "edit":
+            if not self.tree.selection():
+                return
+            current_id = int(self.tree.selection()[0])
+            allocation = self.allocation_cache.get(current_id)
+            if not allocation:
+                return
+            self.selected_id = current_id
+            self._fill_form(allocation)
+            self.path_var.set(self._get_path(current_id))
+        self._set_form_state(True)
+        self.save_button.config(text="Create" if mode == "add" else "Save", state="normal")
+        self.cancel_button.config(state="normal")
+        self.status_var.set(status_message)
+
+    def _cancel_edit(self) -> None:
+        self.mode = "view"
+        self.parent_for_new = None
+        self.save_button.config(state="disabled", text="Save")
+        self.cancel_button.config(state="disabled")
+        self._set_form_state(False)
+        if self.selected_id:
+            allocation = self.allocation_cache.get(self.selected_id)
+            if allocation:
+                self._fill_form(allocation)
+                self.path_var.set(self._get_path(self.selected_id))
+        else:
+            self._clear_form()
+            self.path_var.set("No selection")
+        self.status_var.set("Edit cancelled.")
+
+    def _save_allocation(self) -> None:
+        name = self.name_var.get().strip()
+        if not name:
+            messagebox.showerror("Missing name", "Please provide a name for the allocation.")
+            return
+
+        percent_text = self.percent_var.get().strip()
+        if not percent_text:
+            percent_value = 0.0
+        else:
+            try:
+                percent_value = float(percent_text)
+            except ValueError:
+                messagebox.showerror("Invalid percentage", "Share of parent must be a number.")
+                return
+
+        notes = self.notes_text.get("1.0", "end").strip()
+        currency = self.currency_var.get().strip() or None
+        include = bool(self.include_var.get())
+
+        if self.mode == "add":
+            parent_id = self.parent_for_new
+            sort_order = self.repo.get_next_sort_order(parent_id)
+            allocation = Allocation(
+                id=None,
+                parent_id=parent_id,
+                name=name,
+                currency=currency,
+                target_percent=percent_value,
+                include_in_rollup=include,
+                notes=notes,
+                sort_order=sort_order,
+            )
+            new_id = self.repo.add_allocation(allocation)
+            self.status_var.set(f"Created allocation '{name}'.")
+            self.mode = "view"
+            self.parent_for_new = None
+            self._set_form_state(False)
+            self.save_button.config(state="disabled", text="Save")
+            self.cancel_button.config(state="disabled")
+            self.refresh_tree(select_id=new_id)
+            return
+
+        if self.mode == "edit":
+            if not self.selected_id:
+                return
+            current = self.repo.get_allocation(self.selected_id)
+            if not current:
+                messagebox.showerror("Missing allocation", "The selected allocation no longer exists.")
+                self.refresh_tree()
+                return
+            current.name = name
+            current.currency = currency
+            current.target_percent = percent_value
+            current.include_in_rollup = include
+            current.notes = notes
+            self.repo.update_allocation(current)
+            self.status_var.set(f"Updated allocation '{name}'.")
+            self.mode = "view"
+            self._set_form_state(False)
+            self.save_button.config(state="disabled", text="Save")
+            self.cancel_button.config(state="disabled")
+            self.refresh_tree(select_id=current.id)
+            return
+
+    def _delete_allocation(self) -> None:
+        if not self.tree.selection():
+            messagebox.showinfo("Select a node", "Choose an allocation to delete first.")
+            return
+        allocation_id = int(self.tree.selection()[0])
+        allocation = self.allocation_cache.get(allocation_id)
+        if not allocation:
+            return
+        if not messagebox.askyesno(
+            "Delete allocation",
+            f"Delete '{allocation.name}' and all of its descendants? This action cannot be undone.",
+        ):
+            return
+        self.repo.delete_allocation(allocation_id)
+        self.status_var.set(f"Deleted allocation '{allocation.name}'.")
+        self.mode = "view"
+        self.parent_for_new = None
+        self.selected_id = None
+        self._set_form_state(False)
+        self.save_button.config(state="disabled", text="Save")
+        self.cancel_button.config(state="disabled")
+        self.refresh_tree()
+
+    def _expand_collapse(self, expand: bool) -> None:
+        for item in self.tree.get_children(""):
+            self._expand_recursive(item, expand)
+
+    def _expand_recursive(self, item: str, expand: bool) -> None:
+        self.tree.item(item, open=expand)
+        for child in self.tree.get_children(item):
+            self._expand_recursive(child, expand)
+
+    # ------------------------------------------------------------------
+    # Tree interactions
+    # ------------------------------------------------------------------
+    def refresh_tree(self, *, select_id: Optional[int] = None) -> None:
+        self.tree.delete(*self.tree.get_children())
+        allocations = self.repo.get_all_allocations()
+        self.allocation_cache = {allocation.id: allocation for allocation in allocations}
+
+        nodes: Dict[int, TreeNode] = {}
+        roots: list[TreeNode] = []
+        for allocation in allocations:
+            nodes[allocation.id] = TreeNode(allocation=allocation, children=[])
+        for allocation in allocations:
+            node = nodes[allocation.id]
+            if allocation.parent_id is None or allocation.parent_id not in nodes:
+                roots.append(node)
+            else:
+                nodes[allocation.parent_id].children.append(node)
+
+        def sort_children(items: Iterable[TreeNode]) -> None:
+            for node in items:
+                node.children.sort(key=lambda c: (c.allocation.sort_order, c.allocation.id or 0))
+                sort_children(node.children)
+
+        sort_children(roots)
+        roots.sort(key=lambda n: (n.allocation.sort_order, n.allocation.id or 0))
+
+        for node in roots:
+            self._insert_node("", node, parent_share=100.0)
+
+        if select_id is not None:
+            iid = str(select_id)
+            if iid in self.tree.get_children("") or self.tree.exists(iid):
+                self.tree.selection_set(iid)
+                self.tree.focus(iid)
+                self.tree.see(iid)
+                self.selected_id = select_id
+        elif self.tree.get_children(""):
+            first = self.tree.get_children("")[0]
+            self.tree.selection_set(first)
+            self.tree.focus(first)
+            self.selected_id = int(first)
+        else:
+            self.selected_id = None
+            self._clear_form()
+            self.path_var.set("No selection")
+            self.child_sum_var.set("Children share: 0.00% of parent")
+
+        if self.selected_id:
+            allocation = self.allocation_cache.get(self.selected_id)
+            if allocation:
+                self._fill_form(allocation)
+                self.path_var.set(self._get_path(self.selected_id))
+                self._update_children_summary(self.selected_id)
+
+    def _insert_node(self, parent: str, node: TreeNode, parent_share: float) -> None:
+        allocation = node.allocation
+        own_share = allocation.target_percent
+        cumulative = parent_share * (own_share / 100.0)
+        iid = str(allocation.id)
+        self.tree.insert(
+            parent,
+            "end",
+            iid=iid,
+            text=allocation.name,
+            values=(
+                allocation.normalized_currency,
+                f"{own_share:.2f}%",
+                f"{cumulative:.2f}%",
+                "Yes" if allocation.include_in_rollup else "No",
+            ),
+            open=True,
+        )
+        next_parent_share = cumulative if allocation.include_in_rollup else parent_share
+        for child in node.children:
+            self._insert_node(iid, child, next_parent_share)
+
+    def _on_tree_select(self, event: tk.Event[tk.EventType]) -> None:  # pragma: no cover - UI callback
+        if not self.tree.selection():
+            return
+        iid = int(self.tree.selection()[0])
+        self.selected_id = iid
+        allocation = self.allocation_cache.get(iid)
+        if allocation:
+            self._fill_form(allocation)
+            self.path_var.set(self._get_path(iid))
+            self._update_children_summary(iid)
+        if self.mode != "view":
+            self._cancel_edit()
+
+    # ------------------------------------------------------------------
+    # Form helpers
+    # ------------------------------------------------------------------
+    def _set_form_state(self, enabled: bool) -> None:
+        state = "normal" if enabled else "disabled"
+        for entry in (self.name_entry, self.currency_entry, self.percent_entry):
+            entry.config(state=state)
+        self.include_check.config(state=state)
+        if enabled:
+            self.notes_text.config(state="normal")
+        else:
+            self.notes_text.config(state="disabled")
+
+    def _clear_form(self) -> None:
+        self.name_var.set("")
+        self.currency_var.set("")
+        self.percent_var.set("0")
+        self.include_var.set(True)
+        self.notes_text.config(state="normal")
+        self.notes_text.delete("1.0", "end")
+        self.notes_text.config(state="disabled")
+
+    def _fill_form(self, allocation: Allocation) -> None:
+        self.name_var.set(allocation.name)
+        self.currency_var.set(allocation.normalized_currency)
+        self.percent_var.set(f"{allocation.target_percent:.2f}")
+        self.include_var.set(allocation.include_in_rollup)
+        self.notes_text.config(state="normal")
+        self.notes_text.delete("1.0", "end")
+        if allocation.notes:
+            self.notes_text.insert("1.0", allocation.notes)
+        self.notes_text.config(state="disabled")
+
+    def _update_children_summary(self, allocation_id: int) -> None:
+        children = self.repo.get_children(allocation_id)
+        total = sum(child.target_percent for child in children)
+        self.child_sum_var.set(f"Children share: {total:.2f}% of parent")
+
+    def _get_path(self, allocation_id: Optional[int]) -> str:
+        if allocation_id is None:
+            return ""
+        parts: list[str] = []
+        current_id = allocation_id
+        visited = set()
+        while current_id is not None and current_id not in visited:
+            visited.add(current_id)
+            allocation = self.allocation_cache.get(current_id)
+            if not allocation:
+                break
+            parts.append(allocation.name)
+            current_id = allocation.parent_id if isinstance(allocation.parent_id, int) else None
+        return " > ".join(reversed(parts)) if parts else ""
+
+
+def run_app() -> None:  # pragma: no cover - convenience wrapper for CLI usage
+    root = tk.Tk()
+    style = ttk.Style(root)
+    if "clam" in style.theme_names():
+        style.theme_use("clam")
+    style.configure("Treeview", rowheight=24)
+    AllocationApp(root)
+    root.minsize(960, 600)
+    root.mainloop()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch only
+    run_app()

--- a/moneyalloc_app/db.py
+++ b/moneyalloc_app/db.py
@@ -1,0 +1,188 @@
+"""Database helpers for the Money Allocation application."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List, Optional
+import sqlite3
+
+from .models import Allocation
+
+DB_FILENAME = "allocations.db"
+
+
+class AllocationRepository:
+    """Simple SQLite-backed repository for allocation nodes."""
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        if db_path is None:
+            db_path = Path(__file__).resolve().parent / DB_FILENAME
+        self.db_path = db_path
+        self._ensure_schema()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON;")
+        return conn
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS allocations (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    parent_id INTEGER REFERENCES allocations(id) ON DELETE CASCADE,
+                    name TEXT NOT NULL,
+                    currency TEXT,
+                    target_percent REAL NOT NULL DEFAULT 0.0,
+                    include_in_rollup INTEGER NOT NULL DEFAULT 1,
+                    notes TEXT,
+                    sort_order INTEGER NOT NULL DEFAULT 0
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_allocations_parent
+                    ON allocations(parent_id, sort_order, id)
+                """
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    # CRUD operations
+    # ------------------------------------------------------------------
+    def get_all_allocations(self) -> List[Allocation]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM allocations ORDER BY parent_id IS NOT NULL, parent_id, sort_order, id"
+            ).fetchall()
+        return [self._row_to_allocation(row) for row in rows]
+
+    def get_allocation(self, allocation_id: int) -> Optional[Allocation]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM allocations WHERE id = ?",
+                (allocation_id,),
+            ).fetchone()
+        return self._row_to_allocation(row) if row else None
+
+    def get_children(self, parent_id: Optional[int]) -> List[Allocation]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM allocations WHERE parent_id IS ? ORDER BY sort_order, id",
+                (parent_id,),
+            ).fetchall()
+        return [self._row_to_allocation(row) for row in rows]
+
+    def get_next_sort_order(self, parent_id: Optional[int]) -> int:
+        with self._connect() as conn:
+            result = conn.execute(
+                "SELECT COALESCE(MAX(sort_order), -1) + 1 FROM allocations WHERE parent_id IS ?",
+                (parent_id,),
+            ).fetchone()
+        return int(result[0]) if result else 0
+
+    def add_allocation(self, allocation: Allocation) -> int:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO allocations (parent_id, name, currency, target_percent, include_in_rollup, notes, sort_order)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    allocation.parent_id,
+                    allocation.name,
+                    allocation.currency,
+                    allocation.target_percent,
+                    1 if allocation.include_in_rollup else 0,
+                    allocation.notes,
+                    allocation.sort_order,
+                ),
+            )
+            conn.commit()
+            return int(cursor.lastrowid)
+
+    def update_allocation(self, allocation: Allocation) -> None:
+        if allocation.id is None:
+            raise ValueError("Cannot update an allocation without an id")
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE allocations
+                SET parent_id = ?,
+                    name = ?,
+                    currency = ?,
+                    target_percent = ?,
+                    include_in_rollup = ?,
+                    notes = ?,
+                    sort_order = ?
+                WHERE id = ?
+                """,
+                (
+                    allocation.parent_id,
+                    allocation.name,
+                    allocation.currency,
+                    allocation.target_percent,
+                    1 if allocation.include_in_rollup else 0,
+                    allocation.notes,
+                    allocation.sort_order,
+                    allocation.id,
+                ),
+            )
+            conn.commit()
+
+    def delete_allocation(self, allocation_id: int) -> None:
+        with self._connect() as conn:
+            conn.execute("DELETE FROM allocations WHERE id = ?", (allocation_id,))
+            conn.commit()
+
+    def clear_all(self) -> None:
+        with self._connect() as conn:
+            conn.execute("DELETE FROM allocations")
+            conn.commit()
+
+    def bulk_insert(self, items: Iterable[Allocation]) -> None:
+        with self._connect() as conn:
+            conn.executemany(
+                """
+                INSERT INTO allocations (id, parent_id, name, currency, target_percent, include_in_rollup, notes, sort_order)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        item.id,
+                        item.parent_id,
+                        item.name,
+                        item.currency,
+                        item.target_percent,
+                        1 if item.include_in_rollup else 0,
+                        item.notes,
+                        item.sort_order,
+                    )
+                    for item in items
+                ],
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _row_to_allocation(row: sqlite3.Row) -> Allocation:
+        return Allocation(
+            id=int(row["id"]),
+            parent_id=row["parent_id"],
+            name=row["name"],
+            currency=row["currency"],
+            target_percent=float(row["target_percent"] or 0.0),
+            include_in_rollup=bool(row["include_in_rollup"]),
+            notes=row["notes"] or "",
+            sort_order=int(row["sort_order"] or 0),
+        )
+
+
+__all__ = ["AllocationRepository", "DB_FILENAME"]

--- a/moneyalloc_app/models.py
+++ b/moneyalloc_app/models.py
@@ -1,0 +1,27 @@
+"""Data models for the Money Allocation application."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(slots=True)
+class Allocation:
+    """Represents a single allocation node in the hierarchy."""
+
+    id: Optional[int]
+    parent_id: Optional[int]
+    name: str
+    currency: Optional[str]
+    target_percent: float
+    include_in_rollup: bool
+    notes: str
+    sort_order: int = 0
+
+    @property
+    def normalized_currency(self) -> str:
+        """Return the currency string suitable for display."""
+        return (self.currency or "").strip()
+
+
+__all__ = ["Allocation"]

--- a/moneyalloc_app/sample_data.py
+++ b/moneyalloc_app/sample_data.py
@@ -1,0 +1,952 @@
+"""Sample dataset used to populate the application for the first time."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+from .db import AllocationRepository
+from .models import Allocation
+
+
+@dataclass
+class AllocationSeed:
+    name: str
+    target_percent: float
+    currency: Optional[str] = None
+    include: bool = True
+    notes: str = ""
+    children: Iterable["AllocationSeed"] | None = None
+
+    def as_allocation(self, repo: AllocationRepository, parent_id: Optional[int]) -> Allocation:
+        return Allocation(
+            id=None,
+            parent_id=parent_id,
+            name=self.name,
+            currency=self.currency,
+            target_percent=self.target_percent,
+            include_in_rollup=self.include,
+            notes=self.notes,
+            sort_order=repo.get_next_sort_order(parent_id),
+        )
+
+
+SAMPLE_ALLOCATIONS: list[AllocationSeed] = [
+    AllocationSeed(
+        name="Buffer (1 month income)",
+        target_percent=16.67,
+        include=False,
+        notes="High level bucket that keeps one month worth of income accessible.",
+        children=[
+            AllocationSeed(
+                name="UAH",
+                target_percent=33.33,
+                currency="UAH",
+                notes="Local currency reserves split equally between cash and card balance.",
+                children=[
+                    AllocationSeed(
+                        name="Cash",
+                        target_percent=50.0,
+                        currency="UAH",
+                        include=True,
+                        notes="Emergency banknotes stored at home.",
+                        children=[
+                            AllocationSeed(
+                                name="Cash home",
+                                target_percent=50.0,
+                                currency="UAH",
+                                include=True,
+                                notes="Daily emergency stash kept at home.",
+                            ),
+                            AllocationSeed(
+                                name="Cash pocket",
+                                target_percent=50.0,
+                                currency="UAH",
+                                include=True,
+                                notes="Cash kept on hand for quick access.",
+                            ),
+                        ],
+                    ),
+                    AllocationSeed(
+                        name="Card",
+                        target_percent=50.0,
+                        currency="UAH",
+                        include=True,
+                        notes="Balances on debit cards dedicated to the buffer.",
+                        children=[
+                            AllocationSeed(
+                                name="Card balance",
+                                target_percent=50.0,
+                                currency="UAH",
+                                include=True,
+                                notes="Primary card used for unexpected expenses.",
+                            ),
+                            AllocationSeed(
+                                name="Card balance, %",
+                                target_percent=50.0,
+                                currency="UAH",
+                                include=True,
+                                notes="Interest-bearing card balance reserved for the buffer.",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            AllocationSeed(
+                name="Card balance, %",
+                target_percent=33.33,
+                currency="EUR",
+                include=True,
+                notes="Euro-denominated buffer earning interest.",
+            ),
+            AllocationSeed(
+                name="Card balance, % (USD)",
+                target_percent=33.33,
+                currency="USD",
+                include=True,
+                notes="USD buffer held on an interest bearing account.",
+            ),
+        ],
+    ),
+    AllocationSeed(
+        name="Insurance",
+        target_percent=16.67,
+        include=False,
+        notes="Insurance buckets cover job loss, medical expenses and auto repairs.",
+        children=[
+            AllocationSeed(
+                name="Job (3 month income)",
+                target_percent=16.67,
+                include=False,
+                notes="Savings that secure income in case of job loss.",
+                children=[
+                    AllocationSeed(
+                        name="UAH card balance, %",
+                        target_percent=33.33,
+                        currency="UAH",
+                        include=True,
+                    ),
+                    AllocationSeed(
+                        name="EUR",
+                        target_percent=33.33,
+                        currency="EUR",
+                        include=False,
+                        notes="Euro denominated safe instruments.",
+                        children=[
+                            AllocationSeed(
+                                name="Card balance, %",
+                                target_percent=33.33,
+                                currency="EUR",
+                                include=True,
+                            ),
+                            AllocationSeed(
+                                name="Gov",
+                                target_percent=33.33,
+                                currency="EUR",
+                                include=False,
+                                notes="Government bonds and ETFs.",
+                                children=[
+                                    AllocationSeed(
+                                        name="MMF Gov ETFs",
+                                        target_percent=50.0,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="Bonds Gov 3-month",
+                                        target_percent=50.0,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                ],
+                            ),
+                            AllocationSeed(
+                                name="Corp (MMF Gov+CP ETFs)",
+                                target_percent=33.33,
+                                currency="EUR",
+                                include=True,
+                            ),
+                        ],
+                    ),
+                    AllocationSeed(
+                        name="USD",
+                        target_percent=33.33,
+                        currency="USD",
+                        include=False,
+                        children=[
+                            AllocationSeed(
+                                name="Card balance, %",
+                                target_percent=33.33,
+                                currency="USD",
+                                include=True,
+                            ),
+                            AllocationSeed(
+                                name="Gov",
+                                target_percent=33.33,
+                                currency="USD",
+                                include=False,
+                                children=[
+                                    AllocationSeed(
+                                        name="MMF Gov ETFs",
+                                        target_percent=50.0,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="Bonds Gov 3-month",
+                                        target_percent=50.0,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                ],
+                            ),
+                            AllocationSeed(
+                                name="Corp (MMF Gov+CP ETFs)",
+                                target_percent=33.33,
+                                currency="USD",
+                                include=True,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            AllocationSeed(
+                name="Medical",
+                target_percent=16.67,
+                include=False,
+                children=[
+                    AllocationSeed(
+                        name="UAH card balance, %",
+                        target_percent=33.33,
+                        currency="UAH",
+                        include=True,
+                    ),
+                    AllocationSeed(
+                        name="EUR",
+                        target_percent=33.33,
+                        currency="EUR",
+                        include=False,
+                        children=[
+                            AllocationSeed(
+                                name="Card balance, %",
+                                target_percent=33.33,
+                                currency="EUR",
+                                include=True,
+                            ),
+                            AllocationSeed(
+                                name="MMF Gov ETFs",
+                                target_percent=33.33,
+                                currency="EUR",
+                                include=True,
+                            ),
+                            AllocationSeed(
+                                name="MMF Gov+CP ETFs",
+                                target_percent=33.33,
+                                currency="EUR",
+                                include=True,
+                            ),
+                        ],
+                    ),
+                    AllocationSeed(
+                        name="USD",
+                        target_percent=33.33,
+                        currency="USD",
+                        include=False,
+                        children=[
+                            AllocationSeed(
+                                name="Card balance, %",
+                                target_percent=33.33,
+                                currency="USD",
+                                include=True,
+                            ),
+                            AllocationSeed(
+                                name="MMF Gov ETFs",
+                                target_percent=33.33,
+                                currency="USD",
+                                include=True,
+                            ),
+                            AllocationSeed(
+                                name="MMF Gov+CP ETFs",
+                                target_percent=33.33,
+                                currency="USD",
+                                include=True,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            AllocationSeed(
+                name="Auto",
+                target_percent=16.67,
+                include=False,
+                notes="Split between fast access and longer-term repairs.",
+                children=[
+                    AllocationSeed(
+                        name="40% split",
+                        target_percent=40.0,
+                        include=False,
+                        children=[
+                            AllocationSeed(
+                                name="UAH card balance, %",
+                                target_percent=33.33,
+                                currency="UAH",
+                                include=True,
+                            ),
+                            AllocationSeed(
+                                name="EUR",
+                                target_percent=33.33,
+                                currency="EUR",
+                                include=False,
+                                children=[
+                                    AllocationSeed(
+                                        name="MMF Gov ETFs",
+                                        target_percent=50.0,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="MMF Gov+CP ETFs",
+                                        target_percent=50.0,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                ],
+                            ),
+                            AllocationSeed(
+                                name="USD",
+                                target_percent=33.33,
+                                currency="USD",
+                                include=False,
+                                children=[
+                                    AllocationSeed(
+                                        name="MMF Gov ETFs",
+                                        target_percent=50.0,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="MMF Gov+CP ETFs",
+                                        target_percent=50.0,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    AllocationSeed(
+                        name="60% split",
+                        target_percent=60.0,
+                        include=False,
+                        children=[
+                            AllocationSeed(
+                                name="UAH OVDP (1Y)",
+                                target_percent=33.33,
+                                currency="UAH",
+                                include=True,
+                            ),
+                            AllocationSeed(
+                                name="EUR",
+                                target_percent=33.33,
+                                currency="EUR",
+                                include=False,
+                                children=[
+                                    AllocationSeed(
+                                        name="Gov",
+                                        target_percent=50.0,
+                                        currency="EUR",
+                                        include=False,
+                                        children=[
+                                            AllocationSeed(
+                                                name="MMF Gov ETFs",
+                                                target_percent=50.0,
+                                                currency="EUR",
+                                                include=True,
+                                            ),
+                                            AllocationSeed(
+                                                name="Bonds ladder (3M-1Y)",
+                                                target_percent=50.0,
+                                                currency="EUR",
+                                                include=True,
+                                            ),
+                                        ],
+                                    ),
+                                    AllocationSeed(
+                                        name="Corp",
+                                        target_percent=50.0,
+                                        currency="EUR",
+                                        include=False,
+                                        children=[
+                                            AllocationSeed(
+                                                name="MMF Gov+CP ETFs",
+                                                target_percent=33.33,
+                                                currency="EUR",
+                                                include=True,
+                                            ),
+                                            AllocationSeed(
+                                                name="ETF corp papers (<1Y)",
+                                                target_percent=33.33,
+                                                currency="EUR",
+                                                include=True,
+                                            ),
+                                            AllocationSeed(
+                                                name="Rate-hedged ETF",
+                                                target_percent=33.33,
+                                                currency="EUR",
+                                                include=True,
+                                            ),
+                                        ],
+                                    ),
+                                ],
+                            ),
+                            AllocationSeed(
+                                name="USD",
+                                target_percent=33.33,
+                                currency="USD",
+                                include=False,
+                                children=[
+                                    AllocationSeed(
+                                        name="Gov",
+                                        target_percent=50.0,
+                                        currency="USD",
+                                        include=False,
+                                        children=[
+                                            AllocationSeed(
+                                                name="MMF Gov ETFs",
+                                                target_percent=50.0,
+                                                currency="USD",
+                                                include=True,
+                                            ),
+                                            AllocationSeed(
+                                                name="Bonds ladder (3M-1Y)",
+                                                target_percent=50.0,
+                                                currency="USD",
+                                                include=True,
+                                            ),
+                                        ],
+                                    ),
+                                    AllocationSeed(
+                                        name="Corp",
+                                        target_percent=50.0,
+                                        currency="USD",
+                                        include=False,
+                                        children=[
+                                            AllocationSeed(
+                                                name="MMF Gov+CP ETFs",
+                                                target_percent=33.33,
+                                                currency="USD",
+                                                include=True,
+                                            ),
+                                            AllocationSeed(
+                                                name="ETF corp papers (<1Y)",
+                                                target_percent=33.33,
+                                                currency="USD",
+                                                include=True,
+                                            ),
+                                            AllocationSeed(
+                                                name="Rate-hedged ETF",
+                                                target_percent=33.33,
+                                                currency="USD",
+                                                include=True,
+                                            ),
+                                        ],
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    ),
+    AllocationSeed(
+        name="Savings",
+        target_percent=16.67,
+        include=False,
+        notes="Savings for near-term goals.",
+        children=[
+            AllocationSeed(
+                name="Short goal (<1Y)",
+                target_percent=20.0,
+                include=False,
+                children=[
+                    AllocationSeed(
+                        name="UAH",
+                        target_percent=33.33,
+                        currency="UAH",
+                        include=False,
+                        children=[
+                            AllocationSeed(
+                                name="Card balance, %",
+                                target_percent=50.0,
+                                currency="UAH",
+                                include=True,
+                            ),
+                            AllocationSeed(
+                                name="OVDP (1Y)",
+                                target_percent=50.0,
+                                currency="UAH",
+                                include=True,
+                            ),
+                        ],
+                    ),
+                    AllocationSeed(
+                        name="EUR",
+                        target_percent=33.33,
+                        currency="EUR",
+                        include=False,
+                        children=[
+                            AllocationSeed(
+                                name="Card balance, %",
+                                target_percent=33.33,
+                                currency="EUR",
+                                include=True,
+                            ),
+                            AllocationSeed(
+                                name="Gov",
+                                target_percent=33.33,
+                                currency="EUR",
+                                include=False,
+                                children=[
+                                    AllocationSeed(
+                                        name="MMF Gov ETFs",
+                                        target_percent=50.0,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="Bonds ladder (3M-1Y)",
+                                        target_percent=50.0,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                ],
+                            ),
+                            AllocationSeed(
+                                name="Corp",
+                                target_percent=33.33,
+                                currency="EUR",
+                                include=False,
+                                children=[
+                                    AllocationSeed(
+                                        name="MMF Gov+CP ETFs",
+                                        target_percent=33.33,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="ETF corp papers (<1Y)",
+                                        target_percent=33.33,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="Rate-hedged ETF",
+                                        target_percent=33.33,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    AllocationSeed(
+                        name="USD",
+                        target_percent=33.33,
+                        currency="USD",
+                        include=False,
+                        children=[
+                            AllocationSeed(
+                                name="Card balance, %",
+                                target_percent=33.33,
+                                currency="USD",
+                                include=True,
+                            ),
+                            AllocationSeed(
+                                name="Gov",
+                                target_percent=33.33,
+                                currency="USD",
+                                include=False,
+                                children=[
+                                    AllocationSeed(
+                                        name="MMF Gov ETFs",
+                                        target_percent=50.0,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="Bonds ladder (3M-1Y)",
+                                        target_percent=50.0,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                ],
+                            ),
+                            AllocationSeed(
+                                name="Corp",
+                                target_percent=33.33,
+                                currency="USD",
+                                include=False,
+                                children=[
+                                    AllocationSeed(
+                                        name="MMF Gov+CP ETFs",
+                                        target_percent=33.33,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="ETF corp papers (<1Y)",
+                                        target_percent=33.33,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="Rate-hedged ETF",
+                                        target_percent=33.33,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            AllocationSeed(
+                name="Long goal (<30Y)",
+                target_percent=20.0,
+                include=False,
+                children=[
+                    AllocationSeed(
+                        name="UAH",
+                        target_percent=33.33,
+                        currency="UAH",
+                        include=False,
+                        children=[
+                            AllocationSeed(
+                                name="Card balance, %",
+                                target_percent=50.0,
+                                currency="UAH",
+                                include=True,
+                            ),
+                            AllocationSeed(
+                                name="OVDP (1Y-3Y)",
+                                target_percent=50.0,
+                                currency="UAH",
+                                include=True,
+                            ),
+                        ],
+                    ),
+                    AllocationSeed(
+                        name="EUR",
+                        target_percent=33.33,
+                        currency="EUR",
+                        include=False,
+                        children=[
+                            AllocationSeed(
+                                name="Card balance, %",
+                                target_percent=33.33,
+                                currency="EUR",
+                                include=True,
+                            ),
+                            AllocationSeed(
+                                name="Gov",
+                                target_percent=33.33,
+                                currency="EUR",
+                                include=False,
+                                children=[
+                                    AllocationSeed(
+                                        name="MMF Gov ETFs",
+                                        target_percent=33.33,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="Bonds ladder (3M-30Y)",
+                                        target_percent=33.33,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="ILB ladder",
+                                        target_percent=33.33,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                ],
+                            ),
+                            AllocationSeed(
+                                name="Corp",
+                                target_percent=33.33,
+                                currency="EUR",
+                                include=False,
+                                children=[
+                                    AllocationSeed(
+                                        name="MMF Gov+CP ETFs",
+                                        target_percent=33.33,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="ETF corp papers",
+                                        target_percent=33.33,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="Rate-hedged ETF",
+                                        target_percent=33.33,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    AllocationSeed(
+                        name="USD",
+                        target_percent=33.33,
+                        currency="USD",
+                        include=False,
+                        children=[
+                            AllocationSeed(
+                                name="Card balance, %",
+                                target_percent=33.33,
+                                currency="USD",
+                                include=True,
+                            ),
+                            AllocationSeed(
+                                name="Gov",
+                                target_percent=33.33,
+                                currency="USD",
+                                include=False,
+                                children=[
+                                    AllocationSeed(
+                                        name="MMF Gov ETFs",
+                                        target_percent=33.33,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="Bonds ladder (3M-30Y)",
+                                        target_percent=33.33,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="TIPS ladder",
+                                        target_percent=33.33,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                ],
+                            ),
+                            AllocationSeed(
+                                name="Corp",
+                                target_percent=33.33,
+                                currency="USD",
+                                include=False,
+                                children=[
+                                    AllocationSeed(
+                                        name="MMF Gov+CP ETFs",
+                                        target_percent=33.33,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="ETF corp papers",
+                                        target_percent=33.33,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="Rate-hedged ETF",
+                                        target_percent=33.33,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    ),
+    AllocationSeed(
+        name="Investments",
+        target_percent=16.67,
+        include=False,
+        notes="Long-term investment allocations.",
+        children=[
+            AllocationSeed(
+                name="Fixed term",
+                target_percent=50.0,
+                include=False,
+                children=[
+                    AllocationSeed(
+                        name="UAH",
+                        target_percent=33.33,
+                        currency="UAH",
+                        include=False,
+                        children=[
+                            AllocationSeed(
+                                name="Card balance, %",
+                                target_percent=50.0,
+                                currency="UAH",
+                                include=True,
+                            ),
+                            AllocationSeed(
+                                name="OVDP (1Y-3Y)",
+                                target_percent=50.0,
+                                currency="UAH",
+                                include=True,
+                            ),
+                        ],
+                    ),
+                    AllocationSeed(
+                        name="EUR",
+                        target_percent=33.33,
+                        currency="EUR",
+                        include=False,
+                        children=[
+                            AllocationSeed(
+                                name="Gov",
+                                target_percent=50.0,
+                                currency="EUR",
+                                include=False,
+                                children=[
+                                    AllocationSeed(
+                                        name="MMF Gov ETFs",
+                                        target_percent=33.33,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="Bonds ladder (3M-30Y)",
+                                        target_percent=33.33,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="ILB ladder",
+                                        target_percent=33.33,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                ],
+                            ),
+                            AllocationSeed(
+                                name="Corp",
+                                target_percent=50.0,
+                                currency="EUR",
+                                include=False,
+                                children=[
+                                    AllocationSeed(
+                                        name="MMF Gov+CP ETFs",
+                                        target_percent=33.33,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="ETF corp papers",
+                                        target_percent=33.33,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="Rate-hedged ETF",
+                                        target_percent=33.33,
+                                        currency="EUR",
+                                        include=True,
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    AllocationSeed(
+                        name="USD",
+                        target_percent=33.33,
+                        currency="USD",
+                        include=False,
+                        children=[
+                            AllocationSeed(
+                                name="Gov",
+                                target_percent=50.0,
+                                currency="USD",
+                                include=False,
+                                children=[
+                                    AllocationSeed(
+                                        name="MMF Gov ETFs",
+                                        target_percent=33.33,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="Bonds ladder (3M-30Y)",
+                                        target_percent=33.33,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="TIPS ladder",
+                                        target_percent=33.33,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                ],
+                            ),
+                            AllocationSeed(
+                                name="Corp",
+                                target_percent=50.0,
+                                currency="USD",
+                                include=False,
+                                children=[
+                                    AllocationSeed(
+                                        name="MMF Gov+CP ETFs",
+                                        target_percent=33.33,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="ETF corp papers",
+                                        target_percent=33.33,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                    AllocationSeed(
+                                        name="Rate-hedged ETF",
+                                        target_percent=33.33,
+                                        currency="USD",
+                                        include=True,
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            AllocationSeed(
+                name="Stocks and crypto",
+                target_percent=50.0,
+                include=True,
+                notes="Higher risk, higher reward portion of the investment bucket.",
+            ),
+        ],
+    ),
+]
+
+
+def populate_with_sample_data(repo: AllocationRepository, *, replace: bool = False) -> None:
+    """Insert the sample allocation tree into the repository."""
+
+    if replace:
+        repo.clear_all()
+
+    def _populate(seed: AllocationSeed, parent_id: Optional[int]) -> None:
+        allocation = seed.as_allocation(repo, parent_id)
+        new_id = repo.add_allocation(allocation)
+        for child in seed.children or []:
+            _populate(child, new_id)
+
+    for top_level in SAMPLE_ALLOCATIONS:
+        _populate(top_level, None)


### PR DESCRIPTION
## Summary
- implement a Tkinter desktop application that manages hierarchical money allocations stored in SQLite
- provide CRUD operations, CSV import/export, and a curated sample dataset for rapid onboarding
- document usage instructions and database format in a README

## Testing
- python -m compileall moneyalloc_app

------
https://chatgpt.com/codex/tasks/task_e_68cfdb2b349c8328b69bda4f183dbea3