### PR TITLE
Add distribution planning and history features

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@ It stores your allocations in a local SQLite database (`allocations.db`) and pro
 - Visualise your allocation hierarchy in a multi-column tree view.
 - Create, edit and delete buckets with arbitrary nesting depth.
 - Track both the share relative to the parent bucket and the cumulative share of the overall plan.
+- Record the current monetary value for every allocation and update it as prices move.
 - Mark buckets as *included* or *excluded* from the aggregated roll-up percentages.
 - Attach notes to every allocation for additional context.
+- Generate distribution recommendations for new deposits or rebalancing, including invest/divest guidance based on a tolerance you choose.
 - Import a comprehensive sample dataset or replace your data from a CSV export.
 - Export the current database contents to CSV for backups or further processing.
+- Keep an audit trail of saved distributions and review them at any time.
 
 ## Getting started
 
@@ -40,8 +43,16 @@ On first launch an empty database is created next to the Python modules. Use **F
 - **Delete** removes the selected bucket and all of its descendants.
 - **Expand all / Collapse all** control the visibility of the hierarchy tree.
 - The form on the right displays the details of the selection and exposes fields when you are adding or editing items.
+- Update the **Current value** field whenever the value of an allocation changes (for example after a price movement).
+- The **Tools** menu hosts the distribution calculator and the distribution history browser.
 
 The *Children share* label helps you verify that the percentages of the immediate children sum up correctly for the selected parent.
+
+## Distributing money
+
+Use **Tools → Distribute funds…** to enter the amount you would like to allocate and the maximum deviation (in percentage points) you are willing to tolerate. The dialog calculates the target value for every included allocation, highlights which buckets need investment or divestment and allows you to save the plan to the database.
+
+Saved plans can be reviewed or deleted via **Tools → Distribution history…**. The history view shows the recorded totals, the tolerance that was used and the recommended actions for each allocation.
 
 ## CSV import/export format
 
@@ -55,10 +66,11 @@ Exports contain the following columns:
 | `currency` | Optional currency label. |
 | `target_percent` | Share of the parent bucket expressed as a percentage. |
 | `include_in_rollup` | `1` if the allocation contributes to the overall totals, otherwise `0`. |
+| `current_value` | Tracked monetary value of the allocation. |
 | `notes` | Free-form description or comments. |
 | `sort_order` | Integer describing the order of siblings. |
 
-When importing from CSV you must keep these columns (you can edit the values).  
+When importing from CSV you must keep these columns (you can edit the values).
 The application clears the current database before inserting the imported rows.
 
 ## Database location

--- a/moneyalloc_app/__init__.py
+++ b/moneyalloc_app/__init__.py
@@ -1,6 +1,13 @@
 """Money allocation manager package."""
 from .app import AllocationApp, run_app
 from .db import AllocationRepository
-from .models import Allocation
+from .models import Allocation, Distribution, DistributionEntry
 
-__all__ = ["AllocationApp", "AllocationRepository", "Allocation", "run_app"]
+__all__ = [
+    "AllocationApp",
+    "AllocationRepository",
+    "Allocation",
+    "Distribution",
+    "DistributionEntry",
+    "run_app",
+]

--- a/moneyalloc_app/app.py
+++ b/moneyalloc_app/app.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 import csv
 import tkinter as tk
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
-from tkinter import filedialog, messagebox, ttk
-from typing import Dict, Iterable, Optional
+from tkinter import filedialog, messagebox, simpledialog, ttk
+from typing import Callable, Dict, Iterable, List, Optional
 
 from .db import AllocationRepository
-from .models import Allocation
+from .models import Allocation, Distribution, DistributionEntry
 from .sample_data import populate_with_sample_data
 
 
@@ -17,6 +18,40 @@ from .sample_data import populate_with_sample_data
 class TreeNode:
     allocation: Allocation
     children: list["TreeNode"]
+
+
+@dataclass(slots=True)
+class PlanRow:
+    """Represents a single recommendation entry in the allocation plan."""
+
+    allocation_id: int
+    path: str
+    currency: str
+    target_share: float
+    current_value: float
+    current_share: float
+    target_value: float
+    recommended_change: float
+    share_diff: float
+    action: str
+
+
+def _format_amount(value: float) -> str:
+    """Return a human friendly amount string."""
+
+    return f"{value:,.2f}"
+
+
+def _format_percent(value: float) -> str:
+    """Return a percentage string with two decimals."""
+
+    return f"{value:.2f}%"
+
+
+def _format_share_delta(value: float) -> str:
+    """Return a signed percentage point delta representation."""
+
+    return f"{value:+.2f} pp"
 
 
 class AllocationApp(ttk.Frame):
@@ -34,6 +69,7 @@ class AllocationApp(ttk.Frame):
         self.name_var = tk.StringVar()
         self.currency_var = tk.StringVar()
         self.percent_var = tk.StringVar()
+        self.value_var = tk.StringVar()
         self.include_var = tk.BooleanVar(value=True)
         self.path_var = tk.StringVar(value="No selection")
         self.child_sum_var = tk.StringVar(value="Children share: 0.00% of parent")
@@ -61,6 +97,11 @@ class AllocationApp(ttk.Frame):
         file_menu.add_separator()
         file_menu.add_command(label="Exit", command=self.master.destroy)
         menubar.add_cascade(label="File", menu=file_menu)
+
+        tools_menu = tk.Menu(menubar, tearoff=False)
+        tools_menu.add_command(label="Distribute funds…", command=self._open_distribution_dialog)
+        tools_menu.add_command(label="Distribution history…", command=self._open_distribution_history)
+        menubar.add_cascade(label="Tools", menu=tools_menu)
 
         self.master.config(menu=menubar)
 
@@ -129,18 +170,22 @@ class AllocationApp(ttk.Frame):
         self.percent_entry = ttk.Entry(form, textvariable=self.percent_var)
         self.percent_entry.grid(row=3, column=1, sticky="ew", pady=(6, 0))
 
-        ttk.Label(form, text="Included in roll-up:").grid(row=4, column=0, sticky="w", pady=(6, 0))
-        self.include_check = ttk.Checkbutton(form, variable=self.include_var, text="Yes")
-        self.include_check.grid(row=4, column=1, sticky="w", pady=(6, 0))
+        ttk.Label(form, text="Current value:").grid(row=4, column=0, sticky="w", pady=(6, 0))
+        self.value_entry = ttk.Entry(form, textvariable=self.value_var)
+        self.value_entry.grid(row=4, column=1, sticky="ew", pady=(6, 0))
 
-        ttk.Label(form, text="Notes:").grid(row=5, column=0, sticky="nw", pady=(6, 0))
+        ttk.Label(form, text="Included in roll-up:").grid(row=5, column=0, sticky="w", pady=(6, 0))
+        self.include_check = ttk.Checkbutton(form, variable=self.include_var, text="Yes")
+        self.include_check.grid(row=5, column=1, sticky="w", pady=(6, 0))
+
+        ttk.Label(form, text="Notes:").grid(row=6, column=0, sticky="nw", pady=(6, 0))
         self.notes_text = tk.Text(form, height=8, wrap="word")
-        self.notes_text.grid(row=5, column=1, sticky="nsew", pady=(6, 0))
+        self.notes_text.grid(row=6, column=1, sticky="nsew", pady=(6, 0))
         notes_scroll = ttk.Scrollbar(form, orient="vertical", command=self.notes_text.yview)
         self.notes_text.configure(yscrollcommand=notes_scroll.set)
-        notes_scroll.grid(row=5, column=2, sticky="nsw")
+        notes_scroll.grid(row=6, column=2, sticky="nsw")
 
-        ttk.Label(form, textvariable=self.child_sum_var).grid(row=6, column=0, columnspan=2, sticky="w", pady=(6, 0))
+        ttk.Label(form, textvariable=self.child_sum_var).grid(row=7, column=0, columnspan=2, sticky="w", pady=(6, 0))
 
         # Status bar
         status = ttk.Label(self, textvariable=self.status_var, anchor="w")
@@ -181,7 +226,17 @@ class AllocationApp(ttk.Frame):
             allocations: list[Allocation] = []
             with open(path, "r", encoding="utf-8") as fh:
                 reader = csv.DictReader(fh)
-                required = {"id", "parent_id", "name", "currency", "target_percent", "include_in_rollup", "notes", "sort_order"}
+                required = {
+                    "id",
+                    "parent_id",
+                    "name",
+                    "currency",
+                    "target_percent",
+                    "include_in_rollup",
+                    "current_value",
+                    "notes",
+                    "sort_order",
+                }
                 if not required.issubset(reader.fieldnames or []):
                     missing = required.difference(reader.fieldnames or [])
                     raise ValueError(f"Missing columns in CSV: {', '.join(sorted(missing))}")
@@ -196,6 +251,7 @@ class AllocationApp(ttk.Frame):
                             currency=row["currency"].strip() or None,
                             target_percent=float(row["target_percent"] or 0.0),
                             include_in_rollup=row["include_in_rollup"].strip().lower() in {"1", "true", "yes"},
+                            current_value=float(row["current_value"] or 0.0),
                             notes=row["notes"],
                             sort_order=int(row["sort_order"] or 0),
                         )
@@ -229,6 +285,7 @@ class AllocationApp(ttk.Frame):
                         "currency",
                         "target_percent",
                         "include_in_rollup",
+                        "current_value",
                         "notes",
                         "sort_order",
                     ]
@@ -242,6 +299,7 @@ class AllocationApp(ttk.Frame):
                             allocation.currency or "",
                             f"{allocation.target_percent:.4f}",
                             int(allocation.include_in_rollup),
+                            f"{allocation.current_value:.2f}",
                             allocation.notes,
                             allocation.sort_order,
                         ]
@@ -329,6 +387,16 @@ class AllocationApp(ttk.Frame):
                 messagebox.showerror("Invalid percentage", "Share of parent must be a number.")
                 return
 
+        value_text = self.value_var.get().strip()
+        if not value_text:
+            current_value = 0.0
+        else:
+            try:
+                current_value = float(value_text)
+            except ValueError:
+                messagebox.showerror("Invalid value", "Current value must be a number.")
+                return
+
         notes = self.notes_text.get("1.0", "end").strip()
         currency = self.currency_var.get().strip() or None
         include = bool(self.include_var.get())
@@ -345,6 +413,7 @@ class AllocationApp(ttk.Frame):
                 include_in_rollup=include,
                 notes=notes,
                 sort_order=sort_order,
+                current_value=current_value,
             )
             new_id = self.repo.add_allocation(allocation)
             self.status_var.set(f"Created allocation '{name}'.")
@@ -369,6 +438,7 @@ class AllocationApp(ttk.Frame):
             current.target_percent = percent_value
             current.include_in_rollup = include
             current.notes = notes
+            current.current_value = current_value
             self.repo.update_allocation(current)
             self.status_var.set(f"Updated allocation '{name}'.")
             self.mode = "view"
@@ -409,6 +479,23 @@ class AllocationApp(ttk.Frame):
         self.tree.item(item, open=expand)
         for child in self.tree.get_children(item):
             self._expand_recursive(child, expand)
+
+    # ------------------------------------------------------------------
+    # Distribution helpers
+    # ------------------------------------------------------------------
+    def _open_distribution_dialog(self) -> None:
+        DistributionDialog(self.master, self.repo, self._on_distribution_saved)
+
+    def _open_distribution_history(self) -> None:
+        DistributionHistoryDialog(self.master, self.repo, self._on_distribution_deleted)
+
+    def _on_distribution_saved(self, name: str, count: int) -> None:
+        self.status_var.set(
+            f"Saved distribution '{name}' with {count} recommendation{'s' if count != 1 else ''}."
+        )
+
+    def _on_distribution_deleted(self, name: str) -> None:
+        self.status_var.set(f"Deleted distribution '{name}'.")
 
     # ------------------------------------------------------------------
     # Tree interactions
@@ -505,7 +592,7 @@ class AllocationApp(ttk.Frame):
     # ------------------------------------------------------------------
     def _set_form_state(self, enabled: bool) -> None:
         state = "normal" if enabled else "disabled"
-        for entry in (self.name_entry, self.currency_entry, self.percent_entry):
+        for entry in (self.name_entry, self.currency_entry, self.percent_entry, self.value_entry):
             entry.config(state=state)
         self.include_check.config(state=state)
         if enabled:
@@ -517,6 +604,7 @@ class AllocationApp(ttk.Frame):
         self.name_var.set("")
         self.currency_var.set("")
         self.percent_var.set("0")
+        self.value_var.set("0")
         self.include_var.set(True)
         self.notes_text.config(state="normal")
         self.notes_text.delete("1.0", "end")
@@ -526,6 +614,7 @@ class AllocationApp(ttk.Frame):
         self.name_var.set(allocation.name)
         self.currency_var.set(allocation.normalized_currency)
         self.percent_var.set(f"{allocation.target_percent:.2f}")
+        self.value_var.set(f"{allocation.current_value:.2f}")
         self.include_var.set(allocation.include_in_rollup)
         self.notes_text.config(state="normal")
         self.notes_text.delete("1.0", "end")
@@ -552,6 +641,573 @@ class AllocationApp(ttk.Frame):
             parts.append(allocation.name)
             current_id = allocation.parent_id if isinstance(allocation.parent_id, int) else None
         return " > ".join(reversed(parts)) if parts else ""
+
+
+class DistributionDialog(tk.Toplevel):
+    """Dialog that calculates and persists distribution recommendations."""
+
+    def __init__(
+        self,
+        master: tk.Misc,
+        repo: AllocationRepository,
+        on_saved: Callable[[str, int], None],
+    ) -> None:
+        super().__init__(master)
+        self.repo = repo
+        self.on_saved = on_saved
+        self.plan_rows: list[PlanRow] = []
+        self.amount: float = 0.0
+        self.tolerance: float = 0.0
+        self.totals: dict[str, float] = {
+            "current_total": 0.0,
+            "target_total": 0.0,
+            "invest_total": 0.0,
+            "divest_total": 0.0,
+        }
+
+        self.amount_var = tk.StringVar(value="0")
+        self.tolerance_var = tk.StringVar(value="2.0")
+        self.summary_var = tk.StringVar(value="Enter an amount and press Calculate.")
+
+        self.title("Distribute funds")
+        self.transient(master)
+        self.grab_set()
+        self.resizable(True, True)
+
+        container = ttk.Frame(self, padding=10)
+        container.pack(fill="both", expand=True)
+
+        form = ttk.Frame(container)
+        form.pack(fill="x")
+        form.columnconfigure(4, weight=1)
+
+        ttk.Label(form, text="Amount to distribute:").grid(row=0, column=0, sticky="w")
+        amount_entry = ttk.Entry(form, textvariable=self.amount_var, width=18)
+        amount_entry.grid(row=0, column=1, sticky="w", padx=(4, 12))
+
+        ttk.Label(form, text="Tolerance (pp):").grid(row=0, column=2, sticky="w")
+        ttk.Entry(form, textvariable=self.tolerance_var, width=10).grid(
+            row=0, column=3, sticky="w", padx=(4, 12)
+        )
+
+        ttk.Button(form, text="Calculate", command=self._calculate_plan).grid(
+            row=0, column=4, sticky="e"
+        )
+
+        tree_frame = ttk.Frame(container)
+        tree_frame.pack(fill="both", expand=True, pady=(10, 0))
+        columns = (
+            "currency",
+            "target_share",
+            "current_value",
+            "current_share",
+            "target_value",
+            "change",
+            "share_diff",
+            "action",
+        )
+        self.tree = ttk.Treeview(tree_frame, columns=columns, show="tree headings", height=15)
+        self.tree.heading("#0", text="Allocation")
+        self.tree.column("#0", width=320, anchor="w")
+        self.tree.heading("currency", text="Currency")
+        self.tree.column("currency", width=80, anchor="center")
+        self.tree.heading("target_share", text="Target %")
+        self.tree.column("target_share", width=90, anchor="e")
+        self.tree.heading("current_value", text="Current value")
+        self.tree.column("current_value", width=110, anchor="e")
+        self.tree.heading("current_share", text="Current %")
+        self.tree.column("current_share", width=90, anchor="e")
+        self.tree.heading("target_value", text="Target value")
+        self.tree.column("target_value", width=110, anchor="e")
+        self.tree.heading("change", text="Change")
+        self.tree.column("change", width=110, anchor="e")
+        self.tree.heading("share_diff", text="Δ share")
+        self.tree.column("share_diff", width=90, anchor="e")
+        self.tree.heading("action", text="Action")
+        self.tree.column("action", width=200, anchor="w")
+
+        tree_scroll_y = ttk.Scrollbar(tree_frame, orient="vertical", command=self.tree.yview)
+        tree_scroll_x = ttk.Scrollbar(tree_frame, orient="horizontal", command=self.tree.xview)
+        self.tree.configure(yscrollcommand=tree_scroll_y.set, xscrollcommand=tree_scroll_x.set)
+        self.tree.grid(row=0, column=0, sticky="nsew")
+        tree_scroll_y.grid(row=0, column=1, sticky="ns")
+        tree_scroll_x.grid(row=1, column=0, sticky="ew")
+        tree_frame.rowconfigure(0, weight=1)
+        tree_frame.columnconfigure(0, weight=1)
+
+        ttk.Label(container, textvariable=self.summary_var, anchor="w").pack(
+            fill="x", pady=(10, 0)
+        )
+
+        button_row = ttk.Frame(container)
+        button_row.pack(fill="x", pady=(10, 0))
+        self.save_button = ttk.Button(
+            button_row,
+            text="Save distribution",
+            command=self._save_distribution,
+            state="disabled",
+        )
+        self.save_button.pack(side="left")
+        ttk.Button(button_row, text="Close", command=self.destroy).pack(side="right")
+
+        amount_entry.focus_set()
+
+    # ------------------------------------------------------------------
+    # Plan calculation
+    # ------------------------------------------------------------------
+    def _calculate_plan(self) -> None:
+        try:
+            amount = float(self.amount_var.get())
+        except ValueError:
+            messagebox.showerror("Invalid amount", "The amount to distribute must be a number.", parent=self)
+            return
+        if amount < 0:
+            messagebox.showerror(
+                "Invalid amount",
+                "The amount to distribute cannot be negative.",
+                parent=self,
+            )
+            return
+
+        try:
+            tolerance = float(self.tolerance_var.get())
+        except ValueError:
+            messagebox.showerror(
+                "Invalid tolerance", "The tolerance must be expressed as a number.", parent=self
+            )
+            return
+        if tolerance < 0:
+            messagebox.showerror(
+                "Invalid tolerance", "Tolerance cannot be negative.", parent=self
+            )
+            return
+
+        plan_rows, totals = self._build_plan(amount, tolerance)
+        if not plan_rows:
+            messagebox.showinfo(
+                "No included allocations",
+                "None of the allocations are marked as included in the roll-up, therefore no "
+                "distribution recommendations can be produced.",
+                parent=self,
+            )
+            self.tree.delete(*self.tree.get_children())
+            self.summary_var.set("No plan available. Update your allocations and try again.")
+            self.save_button.config(state="disabled")
+            self.plan_rows = []
+            return
+
+        self.plan_rows = plan_rows
+        self.amount = amount
+        self.tolerance = tolerance
+        self.totals = totals
+        self._populate_tree()
+        self.save_button.config(state="normal")
+
+    def _populate_tree(self) -> None:
+        self.tree.delete(*self.tree.get_children())
+        for row in self.plan_rows:
+            self.tree.insert(
+                "",
+                "end",
+                iid=str(row.allocation_id),
+                text=row.path,
+                values=(
+                    row.currency,
+                    _format_percent(row.target_share),
+                    _format_amount(row.current_value),
+                    _format_percent(row.current_share),
+                    _format_amount(row.target_value),
+                    _format_amount(row.recommended_change),
+                    _format_share_delta(row.share_diff),
+                    row.action,
+                ),
+            )
+
+        invest_total = self.totals.get("invest_total", 0.0)
+        divest_total = abs(self.totals.get("divest_total", 0.0))
+        summary_lines = [
+            f"Current total: {_format_amount(self.totals.get('current_total', 0.0))}",
+            f"Target total: {_format_amount(self.totals.get('target_total', 0.0))} (deposit {_format_amount(self.amount)})",
+            f"Invest: {_format_amount(invest_total)} | Divest: {_format_amount(divest_total)}",
+        ]
+        self.summary_var.set("\n".join(summary_lines))
+
+    def _build_plan(self, amount: float, tolerance: float) -> tuple[list[PlanRow], dict[str, float]]:
+        allocations = self.repo.get_all_allocations()
+        nodes: dict[int, TreeNode] = {}
+        roots: list[TreeNode] = []
+        for allocation in allocations:
+            if allocation.id is None:
+                continue
+            nodes[allocation.id] = TreeNode(allocation=allocation, children=[])
+        if not nodes:
+            return [], {
+                "current_total": 0.0,
+                "target_total": amount,
+                "invest_total": amount,
+                "divest_total": 0.0,
+            }
+
+        for allocation in allocations:
+            if allocation.id is None:
+                continue
+            node = nodes[allocation.id]
+            if allocation.parent_id is None or allocation.parent_id not in nodes:
+                roots.append(node)
+            else:
+                nodes[allocation.parent_id].children.append(node)
+
+        def sort_children(items: Iterable[TreeNode]) -> None:
+            for item in items:
+                item.children.sort(key=lambda c: (c.allocation.sort_order, c.allocation.id or 0))
+                sort_children(item.children)
+
+        sort_children(roots)
+        roots.sort(key=lambda n: (n.allocation.sort_order, n.allocation.id or 0))
+
+        contribute_cache: dict[int, bool] = {}
+
+        def contributes(node: TreeNode) -> bool:
+            key = node.allocation.id if node.allocation.id is not None else id(node)
+            if key in contribute_cache:
+                return contribute_cache[key]
+            contributes_value = node.allocation.include_in_rollup or any(
+                contributes(child) for child in node.children
+            )
+            contribute_cache[key] = contributes_value
+            return contributes_value
+
+        plan_rows: list[PlanRow] = []
+
+        def gather(node: TreeNode, parent_share: float, path: list[str]) -> None:
+            allocation = node.allocation
+            if allocation.id is None:
+                return
+            own_share = allocation.target_percent
+            cumulative_share = parent_share * (own_share / 100.0)
+            current_path = path + [allocation.name]
+            included_children = [child for child in node.children if contributes(child)]
+            if allocation.include_in_rollup and not included_children:
+                plan_rows.append(
+                    PlanRow(
+                        allocation_id=allocation.id,
+                        path=" > ".join(current_path),
+                        currency=allocation.normalized_currency,
+                        target_share=cumulative_share,
+                        current_value=allocation.current_value,
+                        current_share=0.0,
+                        target_value=0.0,
+                        recommended_change=0.0,
+                        share_diff=0.0,
+                        action="",
+                    )
+                )
+            next_parent_share = cumulative_share if allocation.include_in_rollup else parent_share
+            for child in included_children:
+                gather(child, next_parent_share, current_path)
+
+        for root in roots:
+            if contributes(root):
+                gather(root, 100.0, [])
+
+        total_current = sum(row.current_value for row in plan_rows)
+        target_total = total_current + amount
+        invest_total = 0.0
+        divest_total = 0.0
+        for row in plan_rows:
+            row.current_share = (row.current_value / total_current * 100.0) if total_current else 0.0
+            row.target_value = target_total * (row.target_share / 100.0)
+            row.recommended_change = row.target_value - row.current_value
+            row.share_diff = row.target_share - row.current_share
+            if abs(row.share_diff) < tolerance:
+                row.action = f"Within tolerance ({_format_share_delta(row.share_diff)})"
+            elif row.recommended_change >= 0:
+                row.action = f"Invest ({_format_share_delta(row.share_diff)})"
+            else:
+                row.action = f"Divest ({_format_share_delta(row.share_diff)})"
+            if row.recommended_change >= 0:
+                invest_total += row.recommended_change
+            else:
+                divest_total += row.recommended_change
+
+        totals = {
+            "current_total": total_current,
+            "target_total": target_total,
+            "invest_total": invest_total,
+            "divest_total": divest_total,
+        }
+        return plan_rows, totals
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+    def _save_distribution(self) -> None:
+        if not self.plan_rows:
+            return
+        default_name = datetime.now().strftime("Distribution %Y-%m-%d %H:%M")
+        name = simpledialog.askstring(
+            "Save distribution",
+            "Distribution name:",
+            parent=self,
+            initialvalue=default_name,
+        )
+        if name is None:
+            return
+        name = name.strip()
+        if not name:
+            messagebox.showerror("Missing name", "Please provide a name for the distribution.", parent=self)
+            return
+
+        distribution = Distribution(
+            id=None,
+            name=name,
+            total_amount=self.amount,
+            tolerance_percent=self.tolerance,
+            created_at=datetime.now().isoformat(timespec="seconds"),
+        )
+        entries = [
+            DistributionEntry(
+                id=None,
+                distribution_id=0,
+                allocation_id=row.allocation_id,
+                allocation_path=row.path,
+                currency=row.currency,
+                target_share=row.target_share,
+                current_value=row.current_value,
+                current_share=row.current_share,
+                target_value=row.target_value,
+                recommended_change=row.recommended_change,
+                share_diff=row.share_diff,
+                action=row.action,
+            )
+            for row in self.plan_rows
+        ]
+
+        self.repo.create_distribution(distribution, entries)
+        self.on_saved(name, len(entries))
+        messagebox.showinfo(
+            "Distribution saved",
+            f"Saved distribution '{name}' with {len(entries)} recommendation"
+            f"{'s' if len(entries) != 1 else ''}.",
+            parent=self,
+        )
+        self.save_button.config(state="disabled")
+
+
+class DistributionHistoryDialog(tk.Toplevel):
+    """Displays previously stored distribution plans."""
+
+    def __init__(
+        self,
+        master: tk.Misc,
+        repo: AllocationRepository,
+        on_deleted: Callable[[str], None],
+    ) -> None:
+        super().__init__(master)
+        self.repo = repo
+        self.on_deleted = on_deleted
+        self.distributions: list[Distribution] = []
+
+        self.title("Distribution history")
+        self.transient(master)
+        self.grab_set()
+        self.resizable(True, True)
+
+        container = ttk.Frame(self, padding=10)
+        container.pack(fill="both", expand=True)
+
+        paned = ttk.Panedwindow(container, orient="horizontal")
+        paned.pack(fill="both", expand=True)
+
+        left = ttk.Frame(paned)
+        right = ttk.Frame(paned)
+        paned.add(left, weight=1)
+        paned.add(right, weight=3)
+
+        ttk.Label(left, text="Distributions").pack(anchor="w")
+        self.distribution_tree = ttk.Treeview(
+            left,
+            columns=("created", "amount", "tolerance"),
+            show="headings",
+            height=15,
+        )
+        self.distribution_tree.heading("created", text="Created")
+        self.distribution_tree.heading("amount", text="Amount")
+        self.distribution_tree.heading("tolerance", text="Tolerance")
+        self.distribution_tree.column("created", width=170, anchor="w")
+        self.distribution_tree.column("amount", width=100, anchor="e")
+        self.distribution_tree.column("tolerance", width=90, anchor="e")
+        dist_scroll = ttk.Scrollbar(left, orient="vertical", command=self.distribution_tree.yview)
+        self.distribution_tree.configure(yscrollcommand=dist_scroll.set)
+        self.distribution_tree.pack(side="left", fill="both", expand=True, pady=(4, 0))
+        dist_scroll.pack(side="right", fill="y", pady=(4, 0))
+        self.distribution_tree.bind("<<TreeviewSelect>>", self._on_distribution_select)
+
+        ttk.Label(right, text="Recommendations").pack(anchor="w")
+        columns = (
+            "currency",
+            "target_share",
+            "current_value",
+            "current_share",
+            "target_value",
+            "change",
+            "share_diff",
+            "action",
+        )
+        self.entries_tree = ttk.Treeview(
+            right,
+            columns=columns,
+            show="tree headings",
+            height=15,
+        )
+        self.entries_tree.heading("#0", text="Allocation")
+        self.entries_tree.column("#0", width=320, anchor="w")
+        self.entries_tree.heading("currency", text="Currency")
+        self.entries_tree.column("currency", width=80, anchor="center")
+        self.entries_tree.heading("target_share", text="Target %")
+        self.entries_tree.column("target_share", width=90, anchor="e")
+        self.entries_tree.heading("current_value", text="Current value")
+        self.entries_tree.column("current_value", width=110, anchor="e")
+        self.entries_tree.heading("current_share", text="Current %")
+        self.entries_tree.column("current_share", width=90, anchor="e")
+        self.entries_tree.heading("target_value", text="Target value")
+        self.entries_tree.column("target_value", width=110, anchor="e")
+        self.entries_tree.heading("change", text="Change")
+        self.entries_tree.column("change", width=110, anchor="e")
+        self.entries_tree.heading("share_diff", text="Δ share")
+        self.entries_tree.column("share_diff", width=90, anchor="e")
+        self.entries_tree.heading("action", text="Action")
+        self.entries_tree.column("action", width=200, anchor="w")
+        entries_scroll_y = ttk.Scrollbar(right, orient="vertical", command=self.entries_tree.yview)
+        entries_scroll_x = ttk.Scrollbar(right, orient="horizontal", command=self.entries_tree.xview)
+        self.entries_tree.configure(
+            yscrollcommand=entries_scroll_y.set, xscrollcommand=entries_scroll_x.set
+        )
+        self.entries_tree.pack(side="left", fill="both", expand=True, pady=(4, 0))
+        entries_scroll_y.pack(side="right", fill="y", pady=(4, 0))
+        entries_scroll_x.pack(side="bottom", fill="x")
+
+        self.summary_var = tk.StringVar(
+            value="Select a distribution to view its recommendations."
+        )
+        ttk.Label(right, textvariable=self.summary_var, anchor="w").pack(
+            fill="x", pady=(8, 0)
+        )
+
+        button_row = ttk.Frame(container)
+        button_row.pack(fill="x", pady=(10, 0))
+        self.delete_button = ttk.Button(
+            button_row,
+            text="Delete selected",
+            command=self._delete_selected,
+            state="disabled",
+        )
+        self.delete_button.pack(side="left")
+        ttk.Button(button_row, text="Close", command=self.destroy).pack(side="right")
+
+        self._load_distributions()
+
+    # ------------------------------------------------------------------
+    # Data loading
+    # ------------------------------------------------------------------
+    def _load_distributions(self) -> None:
+        self.distribution_tree.delete(*self.distribution_tree.get_children())
+        self.distributions = self.repo.get_distributions()
+        for distribution in self.distributions:
+            self.distribution_tree.insert(
+                "",
+                "end",
+                iid=str(distribution.id),
+                values=(
+                    self._format_timestamp(distribution.created_at),
+                    _format_amount(distribution.total_amount),
+                    _format_share_delta(distribution.tolerance_percent),
+                ),
+            )
+        if not self.distributions:
+            self.summary_var.set("No distributions saved yet.")
+        self.delete_button.config(state="disabled")
+        self.entries_tree.delete(*self.entries_tree.get_children())
+
+    def _on_distribution_select(self, event: tk.Event[tk.EventType]) -> None:  # pragma: no cover
+        selection = self.distribution_tree.selection()
+        if not selection:
+            self.entries_tree.delete(*self.entries_tree.get_children())
+            self.summary_var.set("Select a distribution to view its recommendations.")
+            self.delete_button.config(state="disabled")
+            return
+        dist_id = int(selection[0])
+        distribution = next((d for d in self.distributions if d.id == dist_id), None)
+        if not distribution:
+            return
+        entries = self.repo.get_distribution_entries(dist_id)
+        self._populate_entries(distribution, entries)
+        self.delete_button.config(state="normal")
+
+    def _populate_entries(
+        self, distribution: Distribution, entries: List[DistributionEntry]
+    ) -> None:
+        self.entries_tree.delete(*self.entries_tree.get_children())
+        invest_total = 0.0
+        divest_total = 0.0
+        for entry in entries:
+            self.entries_tree.insert(
+                "",
+                "end",
+                iid=str(entry.id),
+                text=entry.allocation_path,
+                values=(
+                    entry.currency,
+                    _format_percent(entry.target_share),
+                    _format_amount(entry.current_value),
+                    _format_percent(entry.current_share),
+                    _format_amount(entry.target_value),
+                    _format_amount(entry.recommended_change),
+                    _format_share_delta(entry.share_diff),
+                    entry.action,
+                ),
+            )
+            if entry.recommended_change >= 0:
+                invest_total += entry.recommended_change
+            else:
+                divest_total += entry.recommended_change
+
+        summary_lines = [
+            f"Created: {self._format_timestamp(distribution.created_at)}",
+            f"Recorded amount: {_format_amount(distribution.total_amount)}",
+            f"Tolerance: {_format_share_delta(distribution.tolerance_percent)}",
+            f"Invest: {_format_amount(invest_total)} | Divest: {_format_amount(abs(divest_total))}",
+        ]
+        self.summary_var.set("\n".join(summary_lines))
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+    def _delete_selected(self) -> None:
+        selection = self.distribution_tree.selection()
+        if not selection:
+            return
+        dist_id = int(selection[0])
+        distribution = next((d for d in self.distributions if d.id == dist_id), None)
+        if not distribution:
+            return
+        if not messagebox.askyesno(
+            "Delete distribution",
+            f"Delete distribution '{distribution.name}'? This action cannot be undone.",
+            parent=self,
+        ):
+            return
+        self.repo.delete_distribution(dist_id)
+        self.on_deleted(distribution.name)
+        self._load_distributions()
+        self.summary_var.set("Distribution deleted.")
+
+    @staticmethod
+    def _format_timestamp(value: str) -> str:
+        try:
+            return datetime.fromisoformat(value).strftime("%Y-%m-%d %H:%M")
+        except ValueError:  # pragma: no cover - fallback for unexpected formats
+            return value
 
 
 def run_app() -> None:  # pragma: no cover - convenience wrapper for CLI usage

--- a/moneyalloc_app/db.py
+++ b/moneyalloc_app/db.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Iterable, List, Optional
 import sqlite3
 
-from .models import Allocation
+from .models import Allocation, Distribution, DistributionEntry
 
 DB_FILENAME = "allocations.db"
 
@@ -40,7 +40,8 @@ class AllocationRepository:
                     target_percent REAL NOT NULL DEFAULT 0.0,
                     include_in_rollup INTEGER NOT NULL DEFAULT 1,
                     notes TEXT,
-                    sort_order INTEGER NOT NULL DEFAULT 0
+                    sort_order INTEGER NOT NULL DEFAULT 0,
+                    current_value REAL NOT NULL DEFAULT 0.0
                 )
                 """
             )
@@ -48,6 +49,42 @@ class AllocationRepository:
                 """
                 CREATE INDEX IF NOT EXISTS idx_allocations_parent
                     ON allocations(parent_id, sort_order, id)
+                """
+            )
+            # Ensure the table carries the new column when upgrading from older versions.
+            info = conn.execute("PRAGMA table_info(allocations)").fetchall()
+            columns = {row[1] for row in info}
+            if "current_value" not in columns:
+                conn.execute(
+                    "ALTER TABLE allocations ADD COLUMN current_value REAL NOT NULL DEFAULT 0.0"
+                )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS distributions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    total_amount REAL NOT NULL,
+                    tolerance_percent REAL NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS distribution_entries (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    distribution_id INTEGER NOT NULL REFERENCES distributions(id) ON DELETE CASCADE,
+                    allocation_id INTEGER NOT NULL REFERENCES allocations(id) ON DELETE CASCADE,
+                    allocation_path TEXT NOT NULL,
+                    currency TEXT NOT NULL,
+                    target_share REAL NOT NULL,
+                    current_value REAL NOT NULL,
+                    current_share REAL NOT NULL,
+                    target_value REAL NOT NULL,
+                    recommended_change REAL NOT NULL,
+                    share_diff REAL NOT NULL,
+                    action TEXT NOT NULL
+                )
                 """
             )
             conn.commit()
@@ -90,8 +127,8 @@ class AllocationRepository:
         with self._connect() as conn:
             cursor = conn.execute(
                 """
-                INSERT INTO allocations (parent_id, name, currency, target_percent, include_in_rollup, notes, sort_order)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO allocations (parent_id, name, currency, target_percent, include_in_rollup, notes, sort_order, current_value)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     allocation.parent_id,
@@ -101,6 +138,7 @@ class AllocationRepository:
                     1 if allocation.include_in_rollup else 0,
                     allocation.notes,
                     allocation.sort_order,
+                    allocation.current_value,
                 ),
             )
             conn.commit()
@@ -119,7 +157,8 @@ class AllocationRepository:
                     target_percent = ?,
                     include_in_rollup = ?,
                     notes = ?,
-                    sort_order = ?
+                    sort_order = ?,
+                    current_value = ?
                 WHERE id = ?
                 """,
                 (
@@ -130,6 +169,7 @@ class AllocationRepository:
                     1 if allocation.include_in_rollup else 0,
                     allocation.notes,
                     allocation.sort_order,
+                    allocation.current_value,
                     allocation.id,
                 ),
             )
@@ -149,8 +189,8 @@ class AllocationRepository:
         with self._connect() as conn:
             conn.executemany(
                 """
-                INSERT INTO allocations (id, parent_id, name, currency, target_percent, include_in_rollup, notes, sort_order)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO allocations (id, parent_id, name, currency, target_percent, include_in_rollup, notes, sort_order, current_value)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 [
                     (
@@ -162,6 +202,7 @@ class AllocationRepository:
                         1 if item.include_in_rollup else 0,
                         item.notes,
                         item.sort_order,
+                        item.current_value,
                     )
                     for item in items
                 ],
@@ -182,7 +223,119 @@ class AllocationRepository:
             include_in_rollup=bool(row["include_in_rollup"]),
             notes=row["notes"] or "",
             sort_order=int(row["sort_order"] or 0),
+            current_value=float(row["current_value"] or 0.0),
+        )
+
+    # ------------------------------------------------------------------
+    # Distribution helpers
+    # ------------------------------------------------------------------
+    def create_distribution(
+        self, distribution: Distribution, entries: Iterable[DistributionEntry]
+    ) -> int:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO distributions (name, total_amount, tolerance_percent, created_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (
+                    distribution.name,
+                    distribution.total_amount,
+                    distribution.tolerance_percent,
+                    distribution.created_at,
+                ),
+            )
+            distribution_id = int(cursor.lastrowid)
+            conn.executemany(
+                """
+                INSERT INTO distribution_entries (
+                    distribution_id,
+                    allocation_id,
+                    allocation_path,
+                    currency,
+                    target_share,
+                    current_value,
+                    current_share,
+                    target_value,
+                    recommended_change,
+                    share_diff,
+                    action
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        distribution_id,
+                        entry.allocation_id,
+                        entry.allocation_path,
+                        entry.currency,
+                        entry.target_share,
+                        entry.current_value,
+                        entry.current_share,
+                        entry.target_value,
+                        entry.recommended_change,
+                        entry.share_diff,
+                        entry.action,
+                    )
+                    for entry in entries
+                ],
+            )
+            conn.commit()
+        return distribution_id
+
+    def get_distributions(self) -> List[Distribution]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM distributions ORDER BY datetime(created_at) DESC, id DESC"
+            ).fetchall()
+        return [self._row_to_distribution(row) for row in rows]
+
+    def get_distribution_entries(self, distribution_id: int) -> List[DistributionEntry]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT * FROM distribution_entries
+                WHERE distribution_id = ?
+                ORDER BY allocation_path, id
+                """,
+                (distribution_id,),
+            ).fetchall()
+        return [self._row_to_distribution_entry(row) for row in rows]
+
+    def delete_distribution(self, distribution_id: int) -> None:
+        with self._connect() as conn:
+            conn.execute("DELETE FROM distributions WHERE id = ?", (distribution_id,))
+            conn.commit()
+
+    @staticmethod
+    def _row_to_distribution(row: sqlite3.Row) -> Distribution:
+        return Distribution(
+            id=int(row["id"]),
+            name=row["name"],
+            total_amount=float(row["total_amount"] or 0.0),
+            tolerance_percent=float(row["tolerance_percent"] or 0.0),
+            created_at=row["created_at"],
+        )
+
+    @staticmethod
+    def _row_to_distribution_entry(row: sqlite3.Row) -> DistributionEntry:
+        return DistributionEntry(
+            id=int(row["id"]),
+            distribution_id=int(row["distribution_id"]),
+            allocation_id=int(row["allocation_id"]),
+            allocation_path=row["allocation_path"],
+            currency=row["currency"],
+            target_share=float(row["target_share"] or 0.0),
+            current_value=float(row["current_value"] or 0.0),
+            current_share=float(row["current_share"] or 0.0),
+            target_value=float(row["target_value"] or 0.0),
+            recommended_change=float(row["recommended_change"] or 0.0),
+            share_diff=float(row["share_diff"] or 0.0),
+            action=row["action"],
         )
 
 
-__all__ = ["AllocationRepository", "DB_FILENAME"]
+__all__ = [
+    "AllocationRepository",
+    "DB_FILENAME",
+]

--- a/moneyalloc_app/models.py
+++ b/moneyalloc_app/models.py
@@ -17,6 +17,7 @@ class Allocation:
     include_in_rollup: bool
     notes: str
     sort_order: int = 0
+    current_value: float = 0.0
 
     @property
     def normalized_currency(self) -> str:
@@ -24,4 +25,33 @@ class Allocation:
         return (self.currency or "").strip()
 
 
-__all__ = ["Allocation"]
+@dataclass(slots=True)
+class Distribution:
+    """Represents a recorded distribution event."""
+
+    id: Optional[int]
+    name: str
+    total_amount: float
+    tolerance_percent: float
+    created_at: str
+
+
+@dataclass(slots=True)
+class DistributionEntry:
+    """Stores a single recommendation entry inside a distribution."""
+
+    id: Optional[int]
+    distribution_id: int
+    allocation_id: int
+    allocation_path: str
+    currency: str
+    target_share: float
+    current_value: float
+    current_share: float
+    target_value: float
+    recommended_change: float
+    share_diff: float
+    action: str
+
+
+__all__ = ["Allocation", "Distribution", "DistributionEntry"]


### PR DESCRIPTION
## Summary
- extend allocations with current value tracking and expose the field in the editor
- add tools to calculate and persist distribution recommendations with tolerance-aware guidance
- store distribution history in SQLite and expose a viewer for saved plans along with CSV import/export support for current values

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cfea0873b0832885966f3888b54211