### PR TITLE
Fix share propagation for excluded allocations

### DIFF
--- a/moneyalloc_app/app.py
+++ b/moneyalloc_app/app.py
@@ -570,7 +570,7 @@ class AllocationApp(ttk.Frame):
             ),
             open=True,
         )
-        next_parent_share = cumulative if allocation.include_in_rollup else parent_share
+        next_parent_share = cumulative
         for child in node.children:
             self._insert_node(iid, child, next_parent_share)
 
@@ -903,8 +903,8 @@ class DistributionDialog(tk.Toplevel):
                     )
                 )
 
-            next_parent_share = cumulative_share if allocation.include_in_rollup else parent_share
-            
+            next_parent_share = cumulative_share
+
             for child in included_children:
                 gather(child, next_parent_share, current_path)
 


### PR DESCRIPTION
## Summary
- ensure the allocation tree always propagates cumulative share percentages, even when a node is excluded from roll-up
- fix the distribution planner to use the same cumulative share so recommendations honor excluded ancestors

## Testing
- python -m compileall moneyalloc_app

------
https://chatgpt.com/codex/tasks/task_e_68d003bb4c808328bded072f94419387