### PR TITLE
Add instrument support and aggregated distribution summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ On first launch an empty database is created next to the Python modules. Use **F
 - **Expand all / Collapse all** control the visibility of the hierarchy tree.
 - The form on the right displays the details of the selection and exposes fields when you are adding or editing items.
 - Update the **Current value** field whenever the value of an allocation changes (for example after a price movement).
+- Use the **Instrument** field on leaf allocations to label positions that should be aggregated when rebalancing.
 - The **Tools** menu hosts the distribution calculator and the distribution history browser.
 
 The *Children share* label helps you verify that the percentages of the immediate children sum up correctly for the selected parent.
@@ -64,6 +65,7 @@ Exports contain the following columns:
 | `parent_id` | Identifier of the parent allocation (empty for top-level rows). |
 | `name` | Display name of the bucket. |
 | `currency` | Optional currency label. |
+| `instrument` | Optional instrument label used for aggregation in distribution plans. |
 | `target_percent` | Share of the parent bucket expressed as a percentage. |
 | `include_in_rollup` | `1` if the allocation contributes to the overall totals, otherwise `0`. |
 | `current_value` | Tracked monetary value of the allocation. |

--- a/moneyalloc_app/models.py
+++ b/moneyalloc_app/models.py
@@ -13,6 +13,7 @@ class Allocation:
     parent_id: Optional[int]
     name: str
     currency: Optional[str]
+    instrument: Optional[str]
     target_percent: float
     include_in_rollup: bool
     notes: str
@@ -23,6 +24,11 @@ class Allocation:
     def normalized_currency(self) -> str:
         """Return the currency string suitable for display."""
         return (self.currency or "").strip()
+
+    @property
+    def normalized_instrument(self) -> str:
+        """Return the instrument string suitable for display."""
+        return (self.instrument or "").strip()
 
 
 @dataclass(slots=True)

--- a/moneyalloc_app/sample_data.py
+++ b/moneyalloc_app/sample_data.py
@@ -13,6 +13,7 @@ class AllocationSeed:
     name: str
     target_percent: float
     currency: Optional[str] = None
+    instrument: Optional[str] = None
     include: bool = True
     notes: str = ""
     children: Iterable["AllocationSeed"] | None = None
@@ -23,6 +24,7 @@ class AllocationSeed:
             parent_id=parent_id,
             name=self.name,
             currency=self.currency,
+            instrument=self.instrument,
             target_percent=self.target_percent,
             include_in_rollup=self.include,
             notes=self.notes,


### PR DESCRIPTION
## Summary
- add an optional instrument field to allocations, persistence, and CSV import/export
- expose the instrument on the editor form so leaves can be tagged for aggregation
- group distribution recommendations by instrument while keeping per-allocation detail

## Testing
- python -m compileall moneyalloc_app

------
https://chatgpt.com/codex/tasks/task_e_68d04247b6848328a75571130634094f