### PR TITLE
Add time horizon filtering for allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It stores your allocations in a local SQLite database (`allocations.db`) and pro
 - Record the current monetary value for every allocation and update it as prices move.
 - Mark buckets as *included* or *excluded* from the aggregated roll-up percentages.
 - Attach notes to every allocation for additional context.
+- Categorise allocations by time horizon and inherit that classification down the hierarchy.
 - Generate distribution recommendations for new deposits or rebalancing, including invest/divest guidance based on a tolerance you choose.
 - Import a comprehensive sample dataset or replace your data from a CSV export.
 - Export the current database contents to CSV for backups or further processing.
@@ -45,13 +46,14 @@ On first launch an empty database is created next to the Python modules. Use **F
 - The form on the right displays the details of the selection and exposes fields when you are adding or editing items.
 - Update the **Current value** field whenever the value of an allocation changes (for example after a price movement).
 - Use the **Instrument** field on leaf allocations to label positions that should be aggregated when rebalancing.
+- Assign a **Time horizon** to parents or leaves. Empty children inherit the value from the closest ancestor, which can later be used to scope distributions.
 - The **Tools** menu hosts the distribution calculator and the distribution history browser.
 
 The *Children share* label helps you verify that the percentages of the immediate children sum up correctly for the selected parent.
 
 ## Distributing money
 
-Use **Tools → Distribute funds…** to enter the amount you would like to allocate and the maximum deviation (in percentage points) you are willing to tolerate. The dialog calculates the target value for every included allocation, highlights which buckets need investment or divestment and allows you to save the plan to the database.
+Use **Tools → Distribute funds…** to enter the amount you would like to allocate and the maximum deviation (in percentage points) you are willing to tolerate. Optionally select a time horizon to recalculate the target percentages using only leaves that match that classification. The dialog calculates the target value for every included allocation, highlights which buckets need investment or divestment and allows you to save the plan to the database.
 
 Saved plans can be reviewed or deleted via **Tools → Distribution history…**. The history view shows the recorded totals, the tolerance that was used and the recommended actions for each allocation.
 
@@ -66,13 +68,14 @@ Exports contain the following columns:
 | `name` | Display name of the bucket. |
 | `currency` | Optional currency label. |
 | `instrument` | Optional instrument label used for aggregation in distribution plans. |
+| `time_horizon` | Optional textual descriptor (for example *Short term*, *Long term*). |
 | `target_percent` | Share of the parent bucket expressed as a percentage. |
 | `include_in_rollup` | `1` if the allocation contributes to the overall totals, otherwise `0`. |
 | `current_value` | Tracked monetary value of the allocation. |
 | `notes` | Free-form description or comments. |
 | `sort_order` | Integer describing the order of siblings. |
 
-When importing from CSV you must keep these columns (you can edit the values).
+When importing from CSV you must keep these columns (you can edit the values). Older exports that do not yet contain the `time_horizon` column are still supported; empty values are treated as "no classification".
 The application clears the current database before inserting the imported rows.
 
 ## Database location

--- a/moneyalloc_app/db.py
+++ b/moneyalloc_app/db.py
@@ -38,6 +38,7 @@ class AllocationRepository:
                     name TEXT NOT NULL,
                     currency TEXT,
                     instrument TEXT,
+                    time_horizon TEXT,
                     target_percent REAL NOT NULL DEFAULT 0.0,
                     include_in_rollup INTEGER NOT NULL DEFAULT 1,
                     notes TEXT,
@@ -61,6 +62,8 @@ class AllocationRepository:
                 conn.execute(
                     "ALTER TABLE allocations ADD COLUMN current_value REAL NOT NULL DEFAULT 0.0"
                 )
+            if "time_horizon" not in columns:
+                conn.execute("ALTER TABLE allocations ADD COLUMN time_horizon TEXT")
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS distributions (
@@ -135,19 +138,21 @@ class AllocationRepository:
                     name,
                     currency,
                     instrument,
+                    time_horizon,
                     target_percent,
                     include_in_rollup,
                     notes,
                     sort_order,
                     current_value
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     allocation.parent_id,
                     allocation.name,
                     allocation.currency,
                     allocation.instrument,
+                    allocation.time_horizon,
                     allocation.target_percent,
                     1 if allocation.include_in_rollup else 0,
                     allocation.notes,
@@ -173,7 +178,8 @@ class AllocationRepository:
                     include_in_rollup = ?,
                     notes = ?,
                     sort_order = ?,
-                    current_value = ?
+                    current_value = ?,
+                    time_horizon = ?
                 WHERE id = ?
                 """,
                 (
@@ -186,6 +192,7 @@ class AllocationRepository:
                     allocation.notes,
                     allocation.sort_order,
                     allocation.current_value,
+                    allocation.time_horizon,
                     allocation.id,
                 ),
             )
@@ -211,13 +218,14 @@ class AllocationRepository:
                     name,
                     currency,
                     instrument,
+                    time_horizon,
                     target_percent,
                     include_in_rollup,
                     notes,
                     sort_order,
                     current_value
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 [
                     (
@@ -226,6 +234,7 @@ class AllocationRepository:
                         item.name,
                         item.currency,
                         item.instrument,
+                        item.time_horizon,
                         item.target_percent,
                         1 if item.include_in_rollup else 0,
                         item.notes,
@@ -253,6 +262,7 @@ class AllocationRepository:
             notes=row["notes"] or "",
             sort_order=int(row["sort_order"] or 0),
             current_value=float(row["current_value"] or 0.0),
+            time_horizon=row["time_horizon"],
         )
 
     # ------------------------------------------------------------------

--- a/moneyalloc_app/models.py
+++ b/moneyalloc_app/models.py
@@ -19,6 +19,7 @@ class Allocation:
     notes: str
     sort_order: int = 0
     current_value: float = 0.0
+    time_horizon: Optional[str] = None
 
     @property
     def normalized_currency(self) -> str:
@@ -29,6 +30,11 @@ class Allocation:
     def normalized_instrument(self) -> str:
         """Return the instrument string suitable for display."""
         return (self.instrument or "").strip()
+
+    @property
+    def normalized_time_horizon(self) -> str:
+        """Return the time horizon string suitable for display."""
+        return (self.time_horizon or "").strip()
 
 
 @dataclass(slots=True)

--- a/moneyalloc_app/sample_data.py
+++ b/moneyalloc_app/sample_data.py
@@ -14,6 +14,7 @@ class AllocationSeed:
     target_percent: float
     currency: Optional[str] = None
     instrument: Optional[str] = None
+    time_horizon: Optional[str] = None
     include: bool = True
     notes: str = ""
     children: Iterable["AllocationSeed"] | None = None
@@ -29,6 +30,7 @@ class AllocationSeed:
             include_in_rollup=self.include,
             notes=self.notes,
             sort_order=repo.get_next_sort_order(parent_id),
+            time_horizon=self.time_horizon,
         )
 
 


### PR DESCRIPTION
## Summary
- add a configurable time horizon field to allocations, persist it in the database and surface it in the editor
- allow the distribution dialog to filter recommendations by time horizon and renormalise target shares for the selected subset
- document the new workflow and export the additional CSV column

## Testing
- python -m compileall moneyalloc_app

------
https://chatgpt.com/codex/tasks/task_e_68d2a456694083288e5b099da32c880f