### PR TITLE
Enforce numeric time horizon codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It stores your allocations in a local SQLite database (`allocations.db`) and pro
 - Record the current monetary value for every allocation and update it as prices move.
 - Mark buckets as *included* or *excluded* from the aggregated roll-up percentages.
 - Attach notes to every allocation for additional context.
+- Categorise allocations by time horizon and inherit that classification down the hierarchy.
 - Generate distribution recommendations for new deposits or rebalancing, including invest/divest guidance based on a tolerance you choose.
 - Import a comprehensive sample dataset or replace your data from a CSV export.
 - Export the current database contents to CSV for backups or further processing.
@@ -45,13 +46,14 @@ On first launch an empty database is created next to the Python modules. Use **F
 - The form on the right displays the details of the selection and exposes fields when you are adding or editing items.
 - Update the **Current value** field whenever the value of an allocation changes (for example after a price movement).
 - Use the **Instrument** field on leaf allocations to label positions that should be aggregated when rebalancing.
+- Assign a **Time horizon** to parents or leaves using codes such as `6M`, `18M`, `3Y` or `30D`. Empty children inherit the value from the closest ancestor, which can later be used to scope distributions.
 - The **Tools** menu hosts the distribution calculator and the distribution history browser.
 
 The *Children share* label helps you verify that the percentages of the immediate children sum up correctly for the selected parent.
 
 ## Distributing money
 
-Use **Tools → Distribute funds…** to enter the amount you would like to allocate and the maximum deviation (in percentage points) you are willing to tolerate. The dialog calculates the target value for every included allocation, highlights which buckets need investment or divestment and allows you to save the plan to the database.
+Use **Tools → Distribute funds…** to enter the amount you would like to allocate and the maximum deviation (in percentage points) you are willing to tolerate. Optionally select a time horizon to recalculate the target percentages using only leaves that match that classification. The dialog calculates the target value for every included allocation, highlights which buckets need investment or divestment and allows you to save the plan to the database.
 
 Saved plans can be reviewed or deleted via **Tools → Distribution history…**. The history view shows the recorded totals, the tolerance that was used and the recommended actions for each allocation.
 
@@ -66,13 +68,14 @@ Exports contain the following columns:
 | `name` | Display name of the bucket. |
 | `currency` | Optional currency label. |
 | `instrument` | Optional instrument label used for aggregation in distribution plans. |
+| `time_horizon` | Optional descriptor expressed as `<number><unit>` using `Y`, `M`, `W` or `D` (e.g. `6M`, `3Y`, `30D`). |
 | `target_percent` | Share of the parent bucket expressed as a percentage. |
 | `include_in_rollup` | `1` if the allocation contributes to the overall totals, otherwise `0`. |
 | `current_value` | Tracked monetary value of the allocation. |
 | `notes` | Free-form description or comments. |
 | `sort_order` | Integer describing the order of siblings. |
 
-When importing from CSV you must keep these columns (you can edit the values).
+When importing from CSV you must keep these columns (you can edit the values). Older exports that do not yet contain the `time_horizon` column are still supported; empty values are treated as "no classification".
 The application clears the current database before inserting the imported rows.
 
 ## Database location

--- a/moneyalloc_app/app.py
+++ b/moneyalloc_app/app.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import csv
+import math
 import tkinter as tk
 from dataclasses import dataclass
 from datetime import datetime
@@ -12,6 +13,15 @@ from typing import Callable, Dict, Iterable, List, Optional
 from .db import AllocationRepository
 from .models import Allocation, Distribution, DistributionEntry
 from .sample_data import populate_with_sample_data
+from .time_horizon import (
+    merge_time_horizons,
+    normalize_time_horizon,
+    try_normalize_time_horizon,
+)
+
+
+DEFAULT_TIME_HORIZONS: tuple[str, ...] = ("1W", "1M", "3M", "6M", "1Y", "3Y", "5Y")
+ALL_TIME_HORIZONS_OPTION = "All time horizons"
 
 
 @dataclass
@@ -85,6 +95,7 @@ class AllocationApp(ttk.Frame):
         self.name_var = tk.StringVar()
         self.currency_var = tk.StringVar()
         self.instrument_var = tk.StringVar()
+        self.horizon_var = tk.StringVar()
         self.percent_var = tk.StringVar()
         self.value_var = tk.StringVar()
         self.include_var = tk.BooleanVar(value=True)
@@ -145,18 +156,20 @@ class AllocationApp(ttk.Frame):
         tree_frame.rowconfigure(0, weight=1)
         tree_frame.columnconfigure(0, weight=1)
 
-        columns = ("currency", "target", "cumulative", "included")
+        columns = ("currency", "target", "cumulative", "included", "horizon")
         self.tree = ttk.Treeview(tree_frame, columns=columns, show="tree headings", selectmode="browse")
         self.tree.heading("#0", text="Allocation")
         self.tree.heading("currency", text="Currency")
         self.tree.heading("target", text="Share of parent")
         self.tree.heading("cumulative", text="Share of total")
         self.tree.heading("included", text="Included")
+        self.tree.heading("horizon", text="Time horizon")
         self.tree.column("#0", width=240)
         self.tree.column("currency", width=80, anchor="center")
         self.tree.column("target", width=120, anchor="e")
         self.tree.column("cumulative", width=120, anchor="e")
         self.tree.column("included", width=80, anchor="center")
+        self.tree.column("horizon", width=120, anchor="center")
         self.tree.bind("<<TreeviewSelect>>", self._on_tree_select)
         self.tree.grid(row=0, column=0, sticky="nsew")
 
@@ -170,7 +183,7 @@ class AllocationApp(ttk.Frame):
         form = ttk.LabelFrame(self, text="Allocation details")
         form.grid(row=1, column=1, padx=(10, 0), sticky="nsew")
         form.columnconfigure(1, weight=1)
-        form.rowconfigure(7, weight=1)
+        form.rowconfigure(8, weight=1)
 
         ttk.Label(form, text="Path:").grid(row=0, column=0, sticky="w")
         ttk.Label(form, textvariable=self.path_var, wraplength=260).grid(row=0, column=1, sticky="w")
@@ -187,26 +200,35 @@ class AllocationApp(ttk.Frame):
         self.instrument_entry = ttk.Entry(form, textvariable=self.instrument_var)
         self.instrument_entry.grid(row=3, column=1, sticky="ew", pady=(6, 0))
 
-        ttk.Label(form, text="Share of parent (%):").grid(row=4, column=0, sticky="w", pady=(6, 0))
+        ttk.Label(form, text="Time horizon:").grid(row=4, column=0, sticky="w", pady=(6, 0))
+        self.horizon_combo = ttk.Combobox(
+            form,
+            textvariable=self.horizon_var,
+            values=list(DEFAULT_TIME_HORIZONS),
+            width=27,
+        )
+        self.horizon_combo.grid(row=4, column=1, sticky="ew", pady=(6, 0))
+
+        ttk.Label(form, text="Share of parent (%):").grid(row=5, column=0, sticky="w", pady=(6, 0))
         self.percent_entry = ttk.Entry(form, textvariable=self.percent_var)
-        self.percent_entry.grid(row=4, column=1, sticky="ew", pady=(6, 0))
+        self.percent_entry.grid(row=5, column=1, sticky="ew", pady=(6, 0))
 
-        ttk.Label(form, text="Current value:").grid(row=5, column=0, sticky="w", pady=(6, 0))
+        ttk.Label(form, text="Current value:").grid(row=6, column=0, sticky="w", pady=(6, 0))
         self.value_entry = ttk.Entry(form, textvariable=self.value_var)
-        self.value_entry.grid(row=5, column=1, sticky="ew", pady=(6, 0))
+        self.value_entry.grid(row=6, column=1, sticky="ew", pady=(6, 0))
 
-        ttk.Label(form, text="Included in roll-up:").grid(row=6, column=0, sticky="w", pady=(6, 0))
+        ttk.Label(form, text="Included in roll-up:").grid(row=7, column=0, sticky="w", pady=(6, 0))
         self.include_check = ttk.Checkbutton(form, variable=self.include_var, text="Yes")
-        self.include_check.grid(row=6, column=1, sticky="w", pady=(6, 0))
+        self.include_check.grid(row=7, column=1, sticky="w", pady=(6, 0))
 
-        ttk.Label(form, text="Notes:").grid(row=7, column=0, sticky="nw", pady=(6, 0))
+        ttk.Label(form, text="Notes:").grid(row=8, column=0, sticky="nw", pady=(6, 0))
         self.notes_text = tk.Text(form, height=8, wrap="word")
-        self.notes_text.grid(row=7, column=1, sticky="nsew", pady=(6, 0))
+        self.notes_text.grid(row=8, column=1, sticky="nsew", pady=(6, 0))
         notes_scroll = ttk.Scrollbar(form, orient="vertical", command=self.notes_text.yview)
         self.notes_text.configure(yscrollcommand=notes_scroll.set)
-        notes_scroll.grid(row=7, column=2, sticky="nsw")
+        notes_scroll.grid(row=8, column=2, sticky="nsw")
 
-        ttk.Label(form, textvariable=self.child_sum_var).grid(row=8, column=0, columnspan=2, sticky="w", pady=(6, 0))
+        ttk.Label(form, textvariable=self.child_sum_var).grid(row=9, column=0, columnspan=2, sticky="w", pady=(6, 0))
 
         # Status bar
         status = ttk.Label(self, textvariable=self.status_var, anchor="w")
@@ -265,6 +287,14 @@ class AllocationApp(ttk.Frame):
                 for row in reader:
                     if not row["name"].strip():
                         continue
+                    raw_horizon = row.get("time_horizon")
+                    try:
+                        time_horizon = normalize_time_horizon(raw_horizon)
+                    except ValueError as exc:
+                        row_name = row["name"].strip() or "<unnamed>"
+                        raise ValueError(
+                            f"Invalid time horizon '{raw_horizon}' for allocation '{row_name}': {exc}"
+                        ) from exc
                     allocations.append(
                         Allocation(
                             id=int(row["id"]) if row["id"].strip() else None,
@@ -272,6 +302,7 @@ class AllocationApp(ttk.Frame):
                             name=row["name"].strip(),
                             currency=row["currency"].strip() or None,
                             instrument=row["instrument"].strip() or None,
+                            time_horizon=time_horizon,
                             target_percent=float(row["target_percent"] or 0.0),
                             include_in_rollup=row["include_in_rollup"].strip().lower() in {"1", "true", "yes"},
                             current_value=float(row["current_value"] or 0.0),
@@ -307,6 +338,7 @@ class AllocationApp(ttk.Frame):
                         "name",
                         "currency",
                         "instrument",
+                        "time_horizon",
                         "target_percent",
                         "include_in_rollup",
                         "current_value",
@@ -322,6 +354,7 @@ class AllocationApp(ttk.Frame):
                             allocation.name,
                             allocation.currency or "",
                             allocation.instrument or "",
+                            allocation.normalized_time_horizon,
                             f"{allocation.target_percent:.4f}",
                             int(allocation.include_in_rollup),
                             f"{allocation.current_value:.2f}",
@@ -425,6 +458,12 @@ class AllocationApp(ttk.Frame):
         notes = self.notes_text.get("1.0", "end").strip()
         currency = self.currency_var.get().strip() or None
         instrument = self.instrument_var.get().strip() or None
+        try:
+            horizon = normalize_time_horizon(self.horizon_var.get())
+        except ValueError as exc:
+            messagebox.showerror("Invalid time horizon", str(exc))
+            return
+        self.horizon_var.set(horizon or "")
         include = bool(self.include_var.get())
 
         if self.mode == "add":
@@ -436,6 +475,7 @@ class AllocationApp(ttk.Frame):
                 name=name,
                 currency=currency,
                 instrument=instrument,
+                time_horizon=horizon,
                 target_percent=percent_value,
                 include_in_rollup=include,
                 notes=notes,
@@ -463,6 +503,7 @@ class AllocationApp(ttk.Frame):
             current.name = name
             current.currency = currency
             current.instrument = instrument
+            current.time_horizon = horizon
             current.target_percent = percent_value
             current.include_in_rollup = include
             current.notes = notes
@@ -533,6 +574,11 @@ class AllocationApp(ttk.Frame):
         allocations = self.repo.get_all_allocations()
         self.allocation_cache = {allocation.id: allocation for allocation in allocations}
 
+        available_horizons = merge_time_horizons(
+            (allocation.time_horizon for allocation in allocations), DEFAULT_TIME_HORIZONS
+        )
+        self.horizon_combo.configure(values=available_horizons)
+
         nodes: Dict[int, TreeNode] = {}
         roots: list[TreeNode] = []
         for allocation in allocations:
@@ -595,6 +641,7 @@ class AllocationApp(ttk.Frame):
                 f"{own_share:.2f}%",
                 f"{cumulative:.2f}%",
                 "Yes" if allocation.include_in_rollup else "No",
+                allocation.normalized_time_horizon,
             ),
             open=True,
         )
@@ -628,6 +675,7 @@ class AllocationApp(ttk.Frame):
             self.value_entry,
         ):
             entry.config(state=state)
+        self.horizon_combo.config(state=state)
         self.include_check.config(state=state)
         if enabled:
             self.notes_text.config(state="normal")
@@ -638,6 +686,7 @@ class AllocationApp(ttk.Frame):
         self.name_var.set("")
         self.currency_var.set("")
         self.instrument_var.set("")
+        self.horizon_var.set("")
         self.percent_var.set("0")
         self.value_var.set("0")
         self.include_var.set(True)
@@ -649,6 +698,7 @@ class AllocationApp(ttk.Frame):
         self.name_var.set(allocation.name)
         self.currency_var.set(allocation.normalized_currency)
         self.instrument_var.set(allocation.normalized_instrument)
+        self.horizon_var.set(allocation.normalized_time_horizon)
         self.percent_var.set(f"{allocation.target_percent:.2f}")
         self.value_var.set(f"{allocation.current_value:.2f}")
         self.include_var.set(allocation.include_in_rollup)
@@ -704,6 +754,14 @@ class DistributionDialog(tk.Toplevel):
 
         self.amount_var = tk.StringVar(value="0")
         self.tolerance_var = tk.StringVar(value="2.0")
+        self.time_horizon_choices = self._build_time_horizon_choices()
+        default_horizon = (
+            self.time_horizon_choices[0]
+            if self.time_horizon_choices
+            else ALL_TIME_HORIZONS_OPTION
+        )
+        self.time_horizon_var = tk.StringVar(value=default_horizon)
+        self.selected_time_horizon_label = default_horizon
         self.summary_var = tk.StringVar(value="Enter an amount and press Calculate.")
 
         self.title("Distribute funds")
@@ -716,6 +774,7 @@ class DistributionDialog(tk.Toplevel):
 
         form = ttk.Frame(container)
         form.pack(fill="x")
+        form.columnconfigure(1, weight=1)
         form.columnconfigure(4, weight=1)
 
         ttk.Label(form, text="Amount to distribute:").grid(row=0, column=0, sticky="w")
@@ -729,6 +788,18 @@ class DistributionDialog(tk.Toplevel):
 
         ttk.Button(form, text="Calculate", command=self._calculate_plan).grid(
             row=0, column=4, sticky="e"
+        )
+
+        ttk.Label(form, text="Time horizon:").grid(row=1, column=0, sticky="w", pady=(6, 0))
+        self.horizon_filter_combo = ttk.Combobox(
+            form,
+            textvariable=self.time_horizon_var,
+            values=self.time_horizon_choices,
+            state="readonly",
+            width=18,
+        )
+        self.horizon_filter_combo.grid(
+            row=1, column=1, sticky="w", padx=(4, 12), pady=(6, 0)
         )
 
         tree_frame = ttk.Frame(container)
@@ -789,6 +860,15 @@ class DistributionDialog(tk.Toplevel):
 
         amount_entry.focus_set()
 
+    def _build_time_horizon_choices(self) -> list[str]:
+        allocations = self.repo.get_all_allocations()
+        horizons = merge_time_horizons(
+            (allocation.time_horizon for allocation in allocations), DEFAULT_TIME_HORIZONS
+        )
+        if horizons:
+            return [ALL_TIME_HORIZONS_OPTION, *horizons]
+        return [ALL_TIME_HORIZONS_OPTION]
+
     # ------------------------------------------------------------------
     # Plan calculation
     # ------------------------------------------------------------------
@@ -819,14 +899,41 @@ class DistributionDialog(tk.Toplevel):
             )
             return
 
-        plan_rows, totals, instrument_summaries = self._build_plan(amount, tolerance)
+        selected_label = self.time_horizon_var.get().strip()
+        if not selected_label:
+            selected_label = ALL_TIME_HORIZONS_OPTION
+        horizon_filter = (
+            None if selected_label == ALL_TIME_HORIZONS_OPTION else selected_label
+        )
+        if horizon_filter is not None:
+            normalized_filter = try_normalize_time_horizon(horizon_filter)
+            if normalized_filter is None:
+                messagebox.showerror(
+                    "Invalid time horizon",
+                    "Select a time horizon expressed as '<number><unit>' (for example 6M or 3Y).",
+                    parent=self,
+                )
+                return
+            horizon_filter = normalized_filter
+        self.selected_time_horizon_label = selected_label
+        plan_rows, totals, instrument_summaries = self._build_plan(
+            amount, tolerance, horizon_filter
+        )
         if not plan_rows:
-            messagebox.showinfo(
-                "No included allocations",
-                "None of the allocations are marked as included in the roll-up, therefore no "
-                "distribution recommendations can be produced.",
-                parent=self,
-            )
+            if horizon_filter is None:
+                messagebox.showinfo(
+                    "No included allocations",
+                    "None of the allocations are marked as included in the roll-up, therefore no "
+                    "distribution recommendations can be produced.",
+                    parent=self,
+                )
+            else:
+                messagebox.showinfo(
+                    "No matching allocations",
+                    "No allocations match the selected time horizon. Adjust the filter or "
+                    "update the allocation horizons and try again.",
+                    parent=self,
+                )
             self.tree.delete(*self.tree.get_children())
             self.summary_var.set("No plan available. Update your allocations and try again.")
             self.save_button.config(state="disabled")
@@ -914,10 +1021,12 @@ class DistributionDialog(tk.Toplevel):
             f"Target total: {_format_amount(self.totals.get('target_total', 0.0))} (deposit {_format_amount(self.amount)})",
             f"Invest: {_format_amount(invest_total)} | Divest: {_format_amount(divest_total)}",
         ]
+        if self.selected_time_horizon_label:
+            summary_lines.append(f"Time horizon: {self.selected_time_horizon_label}")
         self.summary_var.set("\n".join(summary_lines))
 
     def _build_plan(
-        self, amount: float, tolerance: float
+        self, amount: float, tolerance: float, time_horizon: Optional[str]
     ) -> tuple[list[PlanRow], dict[str, float], list[InstrumentSummary]]:
         allocations = self.repo.get_all_allocations()
         nodes: dict[int, TreeNode] = {}
@@ -951,29 +1060,49 @@ class DistributionDialog(tk.Toplevel):
         sort_children(roots)
         roots.sort(key=lambda n: (n.allocation.sort_order, n.allocation.id or 0))
 
-        contribute_cache: dict[int, bool] = {}
+        filtered_horizon = try_normalize_time_horizon(time_horizon)
 
-        def contributes(node: TreeNode) -> bool:
-            key = node.allocation.id if node.allocation.id is not None else id(node)
+        contribute_cache: dict[tuple[int, Optional[str]], bool] = {}
+
+        def contributes(node: TreeNode, inherited: Optional[str]) -> bool:
+            node_id = node.allocation.id if node.allocation.id is not None else id(node)
+            key = (node_id, inherited)
             if key in contribute_cache:
                 return contribute_cache[key]
-            contributes_value = node.allocation.include_in_rollup or any(
-                contributes(child) for child in node.children
+            node_horizon = try_normalize_time_horizon(node.allocation.time_horizon) or inherited
+            child_contributions = [contributes(child, node_horizon) for child in node.children]
+            has_contributing_child = any(child_contributions)
+            matches_leaf = (
+                node.allocation.include_in_rollup
+                and not has_contributing_child
+                and (filtered_horizon is None or node_horizon == filtered_horizon)
             )
-            contribute_cache[key] = contributes_value
-            return contributes_value
+            result = matches_leaf or has_contributing_child
+            contribute_cache[key] = result
+            return result
 
         plan_rows: list[PlanRow] = []
 
-        def gather(node: TreeNode, parent_share: float, path: list[str]) -> None:
+        def gather(
+            node: TreeNode,
+            parent_share: float,
+            path: list[str],
+            inherited: Optional[str],
+        ) -> None:
             allocation = node.allocation
             if allocation.id is None:
                 return
             own_share = allocation.target_percent
             cumulative_share = parent_share * (own_share / 100.0)
             current_path = path + [allocation.name]
-            included_children = [child for child in node.children if contributes(child)]
-            if allocation.include_in_rollup and not included_children:
+            node_horizon = try_normalize_time_horizon(allocation.time_horizon) or inherited
+            included_children = [child for child in node.children if contributes(child, node_horizon)]
+            is_matching_leaf = (
+                allocation.include_in_rollup
+                and not included_children
+                and (filtered_horizon is None or node_horizon == filtered_horizon)
+            )
+            if is_matching_leaf:
                 plan_rows.append(
                     PlanRow(
                         allocation_id=allocation.id,
@@ -993,11 +1122,19 @@ class DistributionDialog(tk.Toplevel):
             next_parent_share = cumulative_share
 
             for child in included_children:
-                gather(child, next_parent_share, current_path)
+                gather(child, next_parent_share, current_path, node_horizon)
 
         for root in roots:
-            if contributes(root):
-                gather(root, 100.0, [])
+            if contributes(root, None):
+                gather(root, 100.0, [], None)
+
+        total_target_share = sum(row.target_share for row in plan_rows)
+        if math.isclose(total_target_share, 0.0, abs_tol=1e-9):
+            for row in plan_rows:
+                row.target_share = 0.0
+        else:
+            for row in plan_rows:
+                row.target_share = row.target_share / total_target_share * 100.0
 
         total_current = sum(row.current_value for row in plan_rows)
         target_total = total_current + amount

--- a/moneyalloc_app/db.py
+++ b/moneyalloc_app/db.py
@@ -38,6 +38,7 @@ class AllocationRepository:
                     name TEXT NOT NULL,
                     currency TEXT,
                     instrument TEXT,
+                    time_horizon TEXT,
                     target_percent REAL NOT NULL DEFAULT 0.0,
                     include_in_rollup INTEGER NOT NULL DEFAULT 1,
                     notes TEXT,
@@ -61,6 +62,8 @@ class AllocationRepository:
                 conn.execute(
                     "ALTER TABLE allocations ADD COLUMN current_value REAL NOT NULL DEFAULT 0.0"
                 )
+            if "time_horizon" not in columns:
+                conn.execute("ALTER TABLE allocations ADD COLUMN time_horizon TEXT")
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS distributions (
@@ -135,19 +138,21 @@ class AllocationRepository:
                     name,
                     currency,
                     instrument,
+                    time_horizon,
                     target_percent,
                     include_in_rollup,
                     notes,
                     sort_order,
                     current_value
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     allocation.parent_id,
                     allocation.name,
                     allocation.currency,
                     allocation.instrument,
+                    allocation.time_horizon,
                     allocation.target_percent,
                     1 if allocation.include_in_rollup else 0,
                     allocation.notes,
@@ -173,7 +178,8 @@ class AllocationRepository:
                     include_in_rollup = ?,
                     notes = ?,
                     sort_order = ?,
-                    current_value = ?
+                    current_value = ?,
+                    time_horizon = ?
                 WHERE id = ?
                 """,
                 (
@@ -186,6 +192,7 @@ class AllocationRepository:
                     allocation.notes,
                     allocation.sort_order,
                     allocation.current_value,
+                    allocation.time_horizon,
                     allocation.id,
                 ),
             )
@@ -211,13 +218,14 @@ class AllocationRepository:
                     name,
                     currency,
                     instrument,
+                    time_horizon,
                     target_percent,
                     include_in_rollup,
                     notes,
                     sort_order,
                     current_value
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 [
                     (
@@ -226,6 +234,7 @@ class AllocationRepository:
                         item.name,
                         item.currency,
                         item.instrument,
+                        item.time_horizon,
                         item.target_percent,
                         1 if item.include_in_rollup else 0,
                         item.notes,
@@ -253,6 +262,7 @@ class AllocationRepository:
             notes=row["notes"] or "",
             sort_order=int(row["sort_order"] or 0),
             current_value=float(row["current_value"] or 0.0),
+            time_horizon=row["time_horizon"],
         )
 
     # ------------------------------------------------------------------

--- a/moneyalloc_app/models.py
+++ b/moneyalloc_app/models.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
+from .time_horizon import display_time_horizon
+
 
 @dataclass(slots=True)
 class Allocation:
@@ -19,6 +21,7 @@ class Allocation:
     notes: str
     sort_order: int = 0
     current_value: float = 0.0
+    time_horizon: Optional[str] = None
 
     @property
     def normalized_currency(self) -> str:
@@ -29,6 +32,11 @@ class Allocation:
     def normalized_instrument(self) -> str:
         """Return the instrument string suitable for display."""
         return (self.instrument or "").strip()
+
+    @property
+    def normalized_time_horizon(self) -> str:
+        """Return the time horizon string suitable for display."""
+        return display_time_horizon(self.time_horizon)
 
 
 @dataclass(slots=True)

--- a/moneyalloc_app/sample_data.py
+++ b/moneyalloc_app/sample_data.py
@@ -14,6 +14,7 @@ class AllocationSeed:
     target_percent: float
     currency: Optional[str] = None
     instrument: Optional[str] = None
+    time_horizon: Optional[str] = None
     include: bool = True
     notes: str = ""
     children: Iterable["AllocationSeed"] | None = None
@@ -29,6 +30,7 @@ class AllocationSeed:
             include_in_rollup=self.include,
             notes=self.notes,
             sort_order=repo.get_next_sort_order(parent_id),
+            time_horizon=self.time_horizon,
         )
 
 

--- a/moneyalloc_app/time_horizon.py
+++ b/moneyalloc_app/time_horizon.py
@@ -1,0 +1,91 @@
+"""Utilities for parsing and formatting time horizon labels."""
+from __future__ import annotations
+
+import math
+import re
+from typing import Iterable, Optional
+
+__all__ = [
+    "normalize_time_horizon",
+    "try_normalize_time_horizon",
+    "display_time_horizon",
+    "merge_time_horizons",
+]
+
+_VALID_PATTERN = re.compile(r"^(?P<value>\d+)\s*(?P<unit>[YMWD])$", re.IGNORECASE)
+_UNIT_TO_DAYS = {"D": 1, "W": 7, "M": 30, "Y": 365}
+
+
+def normalize_time_horizon(value: Optional[str]) -> Optional[str]:
+    """Return a canonical representation of a time horizon.
+
+    Accepts labels expressed as ``<number><unit>`` or ``<number> <unit>`` where the
+    unit is one of ``Y`` (years), ``M`` (months), ``W`` (weeks) or ``D`` (days).
+    The number must be strictly positive. The function raises :class:`ValueError`
+    when the input does not comply with the expected format.
+    """
+
+    if value is None:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    match = _VALID_PATTERN.fullmatch(text)
+    if not match:
+        raise ValueError(
+            "Time horizon must be expressed as '<number><unit>' (e.g. 6M, 3Y) "
+            "using Y, M, W or D as the unit."
+        )
+    amount = int(match.group("value"))
+    if amount <= 0:
+        raise ValueError("Time horizon value must be greater than zero.")
+    unit = match.group("unit").upper()
+    return f"{amount}{unit}"
+
+
+def try_normalize_time_horizon(value: Optional[str]) -> Optional[str]:
+    """Best-effort normalisation that returns ``None`` for invalid values."""
+
+    try:
+        return normalize_time_horizon(value)
+    except ValueError:
+        return None
+
+
+def display_time_horizon(value: Optional[str]) -> str:
+    """Return a user-facing representation of a stored horizon value."""
+
+    if value is None:
+        return ""
+    text = value.strip()
+    if not text:
+        return ""
+    normalized = try_normalize_time_horizon(text)
+    return normalized if normalized is not None else text
+
+
+def _sort_key(value: str) -> tuple[float, str]:
+    normalized = try_normalize_time_horizon(value)
+    if normalized is None:
+        return (math.inf, value.lower())
+    amount = int(normalized[:-1])
+    unit = normalized[-1]
+    multiplier = _UNIT_TO_DAYS[unit]
+    return (amount * multiplier, normalized.lower())
+
+
+def merge_time_horizons(
+    values: Iterable[Optional[str]], defaults: Iterable[str] = ()
+) -> list[str]:
+    """Combine existing and default horizons into a sorted, de-duplicated list."""
+
+    collected: set[str] = set()
+    for candidate in defaults:
+        normalized = try_normalize_time_horizon(candidate)
+        if normalized:
+            collected.add(normalized)
+    for value in values:
+        normalized = try_normalize_time_horizon(value)
+        if normalized:
+            collected.add(normalized)
+    return sorted(collected, key=_sort_key)


### PR DESCRIPTION
## Summary
- introduce shared utilities to validate, normalise and sort time horizon codes in the <number><unit> format
- validate horizons on CSV import and allocation edits, and drive the UI combos and distribution filtering from the normalised codes
- refresh the README to describe the new horizon syntax for users and CSV workflows

## Testing
- python -m compileall moneyalloc_app

------
https://chatgpt.com/codex/tasks/task_e_68d2a456694083288e5b099da32c880f